### PR TITLE
Add FS2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ To use Trace4Cats within your application add the dependencies listed below as n
 ```scala
 "io.janstenpickle" %% "trace4cats-core" % "0.2.0"
 "io.janstenpickle" %% "trace4cats-inject" % "0.2.0"
+"io.janstenpickle" %% "trace4cats-fs2" % "0.2.0"
 "io.janstenpickle" %% "trace4cats-natchez" % "0.2.0"
 "io.janstenpickle" %% "trace4cats-avro-exporter" % "0.2.0"
 "io.janstenpickle" %% "trace4cats-jaeger-thrift-exporter" % "0.2.0"
@@ -251,6 +252,24 @@ Requires:
 
 ```
 
+
+### [FS2](modules/example/src/main/scala/io/janstenpickle/trace4cats/example/FS2Example.scala)
+
+Demonstrates how a span context can be propagated through an FS2 stream. Uses the 
+[Writer monad](http://eed3si9n.com/herding-cats/Writer.html) to include an [FS2 `EntryPoint`] along side each element. 
+Implicit methods are provided with the import `io.janstenpickle.trace4cats.fs2.syntax.all._` to lift an 
+[FS2 `EntryPoint`] into the stream and use it to perform traced operations within the stream, propagating a span context
+between closures.  
+
+Requires:
+
+```scala
+"io.janstenpickle" %% "trace4cats-core" % "0.2.0"
+"io.janstenpickle" %% "trace4cats-fs2" % "0.2.0"
+"io.janstenpickle" %% "trace4cats-avro-exporter" % "0.2.0"
+
+```
+
 ## [`native-image`] Compatibility
 
 The following span completers have been found to be compatible with [`native-image`]:
@@ -274,6 +293,8 @@ The following span completers have been found to be compatible with [`native-ima
 - [x] OTLP HTTP exporter
 
 
+[FS2]: https:/fs2.io/
+[FS2 `EntryPoint`]: fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/FS2EntryPoint.scala
 [Jaeger]: https://www.jaegertracing.io/
 [Log4Cats]: https://github.com/ChristopherDavenport/log4cats
 [Natchez]: https://github.com/tpolecat/natchez

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val root = (project in file("."))
     kernel,
     avro,
     inject,
+    fs2,
     `avro-exporter`,
     `avro-server`,
     `avro-test`,
@@ -114,6 +115,7 @@ lazy val example = (project in file("modules/example"))
     kernel,
     core,
     inject,
+    fs2,
     natchez,
     `avro-exporter`,
     `log-exporter`,
@@ -384,6 +386,11 @@ lazy val inject = (project in file("modules/inject"))
   .settings(publishSettings)
   .settings(name := "trace4cats-inject")
   .dependsOn(model, kernel, core)
+
+lazy val fs2 = (project in file("modules/fs2"))
+  .settings(publishSettings)
+  .settings(name := "trace4cats-fs2", libraryDependencies ++= Seq(Dependencies.fs2))
+  .dependsOn(model, kernel, core, inject)
 
 lazy val natchez = (project in file("modules/natchez"))
   .settings(publishSettings)

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Fs2Example.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Fs2Example.scala
@@ -1,0 +1,128 @@
+package io.janstenpickle.trace4cats.example
+
+import java.util.concurrent.TimeUnit
+
+import cats.data.{Kleisli, WriterT}
+import cats.effect.{Blocker, Bracket, Clock, Concurrent, ContextShift, ExitCode, IO, IOApp, Resource, Sync, Timer}
+import cats.implicits._
+import cats.{Applicative, Functor, Monad, Order, Parallel}
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.janstenpickle.trace4cats.Span
+import io.janstenpickle.trace4cats.avro.AvroSpanCompleter
+import io.janstenpickle.trace4cats.fs2.Fs2EntryPoint
+import io.janstenpickle.trace4cats.fs2.syntax.all._
+import io.janstenpickle.trace4cats.inject.Trace
+import io.janstenpickle.trace4cats.kernel.SpanSampler
+import io.janstenpickle.trace4cats.model.AttributeValue.LongValue
+import io.janstenpickle.trace4cats.model.{SpanContext, SpanKind, TraceProcess}
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+object Fs2Example extends IOApp {
+
+  def entryPoint[F[_]: Concurrent: ContextShift: Timer: Parallel: Logger](
+    blocker: Blocker,
+    process: TraceProcess
+  ): Resource[F, Fs2EntryPoint[F]] =
+    AvroSpanCompleter.udp[F](blocker, process, batchTimeout = 50.millis).map { completer =>
+      Fs2EntryPoint[F](SpanSampler.probabilistic[F](0.05), completer)
+    }
+
+  // Intentionally slow parallel quicksort, to demonstrate branching. If we run too quickly it seems
+  // to break Jaeger with "skipping clock skew adjustment" so let's pause a bit each time.
+  def qsort[F[_]: Monad: Parallel: Trace: Timer, A: Order](as: List[A]): F[List[A]] =
+    Trace[F].span(as.mkString(",")) {
+      Timer[F].sleep(10.milli) *> {
+        as match {
+          case Nil => Monad[F].pure(Nil)
+          case h :: t =>
+            val (a, b) = t.partition(_ <= h)
+            (qsort[F, A](a), qsort[F, A](b)).parMapN(_ ++ List(h) ++ _)
+        }
+      }
+    }
+
+  def runF[F[_]: Sync: Trace: Parallel: Timer](timeMs: String): F[Unit] =
+    Trace[F].span("Sort some stuff!") {
+      for {
+        _ <- Sync[F].delay(println(timeMs))
+        as <- Sync[F].delay(List.fill(100)(Random.nextInt(1000)))
+        _ <- qsort[F, Int](as)
+      } yield ()
+    }
+
+  def sourceStream[F[_]: Functor: Timer]: Stream[F, FiniteDuration] = Stream.awakeEvery[F](10.seconds)
+
+  // uses WriterT to inject the Fs2EntryPoint with element in the stream
+  def inject[F[_]: Functor: Timer](ep: Fs2EntryPoint[F]): WriterT[Stream[F, *], Fs2EntryPoint[F], FiniteDuration] =
+    sourceStream[F].inject(ep)
+
+  // after the first call to `evalMap` a `SpanContext` is propagated alongside the entry point
+  def doWork[F[_]: Bracket[*[_], Throwable]: Clock](
+    stream: WriterT[Stream[F, *], Fs2EntryPoint[F], FiniteDuration]
+  ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), Long] =
+    stream
+    // eval some effect within a span
+      .evalMap("this is the root span", SpanKind.Consumer, "optional-attribute" -> true) { dur =>
+        Clock[F].realTime(TimeUnit.MILLISECONDS).map(_ + dur.toMillis)
+      }
+
+  // perform a map operation on the underlying stream where each element is traced
+  def map[F[_]: Bracket[*[_], Throwable]: Clock](
+    stream: WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), Long]
+  ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), String] =
+    stream.traceMapChunk("map", "opt-attr-2" -> LongValue(1))(_.toString)
+
+  // `evalMapTrace` takes a function which transforms A => Kleisli[F, Span[F], B] and injects a root or child span
+  // to the evaluation. This allows implicit resolution of the `Trace` typeclass in any methods accessed within the
+  // evaluation
+  def doTracedWork[F[_]: Sync: Parallel: Timer](
+    stream: WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), String]
+  ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), Unit] =
+    stream.evalMapTrace("this is a child span of the root", SpanKind.Consumer) { time =>
+      runF[Kleisli[F, Span[F], *]](time)
+    }
+
+  // gets the trace headers from the span context so that they may be propagated across service boundaries
+  def getHeaders[F[_]](
+    stream: WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), Unit]
+  ): Stream[F, (Map[String, String], Unit)] =
+    stream.traceHeaders
+
+  def continue[F[_]: Bracket[*[_], Throwable]](
+    ep: Fs2EntryPoint[F],
+    stream: Stream[F, (Map[String, String], Unit)]
+  ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), Unit] =
+    // inject the entry point and extract headers from the stream element
+    stream
+      .injectContinue(ep)(_._1)
+      .evalMap("child span in new service", SpanKind.Consumer) { _ =>
+        Applicative[F].unit
+      }
+
+  override def run(args: List[String]): IO[ExitCode] =
+    (for {
+      blocker <- Blocker[IO]
+      implicit0(logger: Logger[IO]) <- Resource.liftF(Slf4jLogger.create[IO])
+      ep <- entryPoint[IO](blocker, TraceProcess("trace4catsFS2"))
+    } yield ep)
+      .use { ep =>
+        // inject the entry point into an infinite stream, do some work,
+        // then export the trace context as message headers
+        val headersStream = getHeaders(
+          inject(ep)
+            .through(doWork[IO])
+            .through(map[IO])
+            .through(doTracedWork[IO])
+        )
+
+        // simulate going across service boundaries by using the message headers
+        val continuedStream = continue(ep, headersStream)
+
+        continuedStream.run.compile.drain
+      }
+      .as(ExitCode.Success)
+}

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/InjectExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/InjectExample.scala
@@ -72,7 +72,7 @@ object InjectExample extends IOApp {
     (for {
       blocker <- Blocker[IO]
       implicit0(logger: Logger[IO]) <- Resource.liftF(Slf4jLogger.create[IO])
-      ep <- entryPoint[IO](blocker, TraceProcess("natchez"))
+      ep <- entryPoint[IO](blocker, TraceProcess("trace4cats"))
     } yield ep)
       .use { ep =>
         ep.root("this is the root span").use { span =>

--- a/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/Fs2EntryPoint.scala
+++ b/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/Fs2EntryPoint.scala
@@ -1,0 +1,56 @@
+package io.janstenpickle.trace4cats.fs2
+
+import cats.{~>, Applicative, Defer}
+import cats.effect.{Clock, Resource, Sync}
+import io.janstenpickle.trace4cats.{Span, ToHeaders}
+import io.janstenpickle.trace4cats.inject.EntryPoint
+import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
+import io.janstenpickle.trace4cats.model.{SpanContext, SpanKind}
+
+trait Fs2EntryPoint[F[_]] extends EntryPoint[F] {
+  def continue(name: String, context: SpanContext): Resource[F, Span[F]] = continue(name, SpanKind.Internal, context)
+  def continue(name: String, kind: SpanKind, context: SpanContext): Resource[F, Span[F]]
+  def mapK[G[_]: Defer: Applicative](fk: F ~> G): Fs2EntryPoint[G] = Fs2EntryPoint.mapK(fk)(this)
+}
+
+object Fs2EntryPoint {
+  def apply[F[_]: Sync: Clock](
+    sampler: SpanSampler[F],
+    completer: SpanCompleter[F],
+    toHeaders: ToHeaders = ToHeaders.w3c
+  ): Fs2EntryPoint[F] = new Fs2EntryPoint[F] {
+    override def root(name: String, kind: SpanKind): Resource[F, Span[F]] =
+      Span.root[F](name, kind, sampler, completer)
+
+    override def continueOrElseRoot(name: String, kind: SpanKind, headers: Map[String, String]): Resource[F, Span[F]] =
+      toHeaders.toContext(headers).fold(root(name, kind)) { parent =>
+        Span.child[F](name, parent, kind, sampler, completer)
+      }
+
+    override def continue(name: String, kind: SpanKind, context: SpanContext): Resource[F, Span[F]] =
+      Span.child[F](name, context, kind, sampler, completer)
+  }
+
+  def noop[F[_]: Applicative]: EntryPoint[F] = new Fs2EntryPoint[F] {
+    override def root(name: String, kind: SpanKind): Resource[F, Span[F]] = Span.noop[F]
+    override def continueOrElseRoot(name: String, kind: SpanKind, headers: Map[String, String]): Resource[F, Span[F]] =
+      Span.noop[F]
+    override def continue(name: String, kind: SpanKind, context: SpanContext): Resource[F, Span[F]] = Span.noop[F]
+  }
+
+  private def mapK[F[_], G[_]: Defer: Applicative](fk: F ~> G)(ep: Fs2EntryPoint[F]): Fs2EntryPoint[G] =
+    new Fs2EntryPoint[G] {
+      override def continue(name: String, kind: SpanKind, context: SpanContext): Resource[G, Span[G]] =
+        ep.continue(name, kind, context).mapK(fk).map(_.mapK(fk))
+
+      override def root(name: String, kind: SpanKind): Resource[G, Span[G]] =
+        ep.root(name, kind).mapK(fk).map(_.mapK(fk))
+
+      override def continueOrElseRoot(
+        name: String,
+        kind: SpanKind,
+        headers: Map[String, String]
+      ): Resource[G, Span[G]] =
+        ep.continueOrElseRoot(name, kind, headers).mapK(fk).map(_.mapK(fk))
+    }
+}

--- a/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/syntax/Fs2StreamSyntax.scala
+++ b/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/syntax/Fs2StreamSyntax.scala
@@ -1,0 +1,160 @@
+package io.janstenpickle.trace4cats.fs2.syntax
+
+import cats.data.{Kleisli, WriterT}
+import cats.effect.{Bracket, Resource}
+import cats.syntax.apply._
+import cats.syntax.functor._
+import cats.{~>, Applicative, Defer}
+import fs2.Stream
+import io.janstenpickle.trace4cats.fs2.Fs2EntryPoint
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanContext, SpanKind}
+import io.janstenpickle.trace4cats.{Span, ToHeaders}
+
+trait Fs2StreamSyntax {
+  implicit class InjectEntryPoint[F[_], A](stream: Stream[F, A]) {
+    def inject(ep: Fs2EntryPoint[F]): WriterT[Stream[F, *], Fs2EntryPoint[F], A] = WriterT(stream.map(ep -> _))
+    def injectContinue(
+      ep: Fs2EntryPoint[F]
+    )(f: A => Map[String, String]): WriterT[Stream[F, *], (Fs2EntryPoint[F], Map[String, String]), A] =
+      WriterT(stream.map(a => (ep, f(a)) -> a))
+  }
+
+  trait EvalOps[F[_], L, A] {
+    protected def stream: WriterT[Stream[F, *], L, A]
+
+    protected def makeSpan[B](name: String, kind: SpanKind, l: L)(
+      implicit F: Applicative[F]
+    ): Resource[F, (Fs2EntryPoint[F], Span[F])]
+
+    private def evalTrace[B](name: String, kind: SpanKind)(
+      f: A => Kleisli[F, Span[F], B]
+    )(implicit F: Bracket[F, Throwable]): (L, A) => F[((Fs2EntryPoint[F], SpanContext), B)] = {
+      case (l, a) =>
+        makeSpan(name, kind, l).use {
+          case (ep, span) => f(a).run(span).map((ep, span.context) -> _)
+        }
+    }
+
+    private def eval[B](name: String, kind: SpanKind, attributes: (String, AttributeValue)*)(
+      f: A => F[B]
+    )(implicit F: Bracket[F, Throwable]): (L, A) => F[((Fs2EntryPoint[F], SpanContext), B)] = {
+      case (l, a) =>
+        makeSpan(name, kind, l).use {
+          case (ep, span) => span.putAll(attributes: _*) *> f(a).map((ep, span.context) -> _)
+        }
+    }
+
+    def through[B](
+      f: WriterT[Stream[F, *], L, A] => WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B]
+    ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] = f(stream)
+
+    def evalMapTrace[B](name: String)(f: A => Kleisli[F, Span[F], B])(
+      implicit F: Bracket[F, Throwable]
+    ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] = evalMapTrace(name, SpanKind.Internal)(f)
+
+    def evalMapTrace[B](name: String, kind: SpanKind)(
+      f: A => Kleisli[F, Span[F], B]
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      WriterT(stream.run.evalMap(evalTrace(name, kind)(f).tupled))
+
+    def evalMapChunkTrace[B](name: String)(f: A => Kleisli[F, Span[F], B])(
+      implicit F: Bracket[F, Throwable]
+    ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] = evalMapChunkTrace(name, SpanKind.Internal)(f)
+
+    def evalMapChunkTrace[B](name: String, kind: SpanKind)(
+      f: A => Kleisli[F, Span[F], B]
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      WriterT(stream.run.evalMapChunk(evalTrace(name, kind)(f).tupled))
+
+    def evalMap[B](name: String, attributes: (String, AttributeValue)*)(f: A => F[B])(
+      implicit F: Bracket[F, Throwable]
+    ): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] = evalMap(name, SpanKind.Internal, attributes: _*)(f)
+
+    def evalMap[B](name: String, kind: SpanKind, attributes: (String, AttributeValue)*)(
+      f: A => F[B]
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      WriterT(stream.run.evalMap(eval(name, kind, attributes: _*)(f).tupled))
+
+    def evalMapChunk[B](name: String, attributes: (String, AttributeValue)*)(
+      f: A => F[B]
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      evalMapChunk(name, SpanKind.Internal, attributes: _*)(f)
+
+    def evalMapChunk[B](name: String, kind: SpanKind, attributes: (String, AttributeValue)*)(
+      f: A => F[B]
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      WriterT(stream.run.evalMapChunk(eval(name, kind, attributes: _*)(f).tupled))
+
+    def traceMapChunk[B](name: String, attributes: (String, AttributeValue)*)(
+      f: A => B
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      traceMapChunk[B](name, SpanKind.Internal, attributes: _*)(f)
+
+    def traceMapChunk[B](name: String, kind: SpanKind, attributes: (String, AttributeValue)*)(
+      f: A => B
+    )(implicit F: Bracket[F, Throwable]): WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), B] =
+      WriterT(stream.run.evalMapChunk(eval(name, kind, attributes: _*)(a => Applicative[F].pure(f(a))).tupled))
+  }
+
+  implicit class RootTrace[F[_], A](override val stream: WriterT[Stream[F, *], Fs2EntryPoint[F], A])
+      extends EvalOps[F, Fs2EntryPoint[F], A] {
+    override protected def makeSpan[B](name: String, kind: SpanKind, l: Fs2EntryPoint[F])(
+      implicit F: Applicative[F]
+    ): Resource[F, (Fs2EntryPoint[F], Span[F])] = l.root(name, kind).map(l -> _)
+
+    def translate[G[_], M](
+      fk: F ~> G
+    )(implicit G: Applicative[G], defer: Defer[G]): WriterT[Stream[G, *], Fs2EntryPoint[G], A] =
+      WriterT(stream.run.translate(fk).map { case (ep, a) => ep.mapK(fk) -> a })
+  }
+
+  implicit class ContinueOrElseRoot[F[_], A](
+    override val stream: WriterT[Stream[F, *], (Fs2EntryPoint[F], Map[String, String]), A]
+  ) extends EvalOps[F, (Fs2EntryPoint[F], Map[String, String]), A] {
+    override protected def makeSpan[B](name: String, kind: SpanKind, l: (Fs2EntryPoint[F], Map[String, String]))(
+      implicit F: Applicative[F]
+    ): Resource[F, (Fs2EntryPoint[F], Span[F])] = l match {
+      case (ep, headers) => ep.continueOrElseRoot(name, kind, headers).map(ep -> _)
+    }
+
+    def translate[G[_], M](
+      fk: F ~> G
+    )(implicit G: Applicative[G], defer: Defer[G]): WriterT[Stream[G, *], (Fs2EntryPoint[G], Map[String, String]), A] =
+      WriterT(stream.run.translate(fk).map { case ((ep, headers), a) => (ep.mapK(fk), headers) -> a })
+  }
+
+  implicit class Continue[F[_], A](override val stream: WriterT[Stream[F, *], (Fs2EntryPoint[F], SpanContext), A])
+      extends EvalOps[F, (Fs2EntryPoint[F], SpanContext), A] {
+
+    override protected def makeSpan[B](name: String, kind: SpanKind, l: (Fs2EntryPoint[F], SpanContext))(
+      implicit F: Applicative[F]
+    ): Resource[F, (Fs2EntryPoint[F], Span[F])] = l match {
+      case (ep, context) => ep.continue(name, kind, context).map(ep -> _)
+    }
+
+    def translate[G[_], M](
+      fk: F ~> G
+    )(implicit G: Applicative[G], defer: Defer[G]): WriterT[Stream[G, *], (Fs2EntryPoint[G], SpanContext), A] =
+      WriterT(stream.run.translate(fk).map { case ((ep, context), a) => (ep.mapK(fk), context) -> a })
+
+    def traceHeaders: Stream[F, (Map[String, String], A)] = traceHeaders(ToHeaders.w3c)
+    def traceHeaders(toHeaders: ToHeaders): Stream[F, (Map[String, String], A)] = stream.run.map {
+      case ((_, context), a) => toHeaders.fromContext(context) -> a
+    }
+
+    def mapTraceHeaders[B](f: (Map[String, String], A) => B): Stream[F, B] = mapTraceHeaders[B](ToHeaders.w3c)(f)
+    def mapTraceHeaders[B](toHeaders: ToHeaders)(f: (Map[String, String], A) => B): Stream[F, B] = stream.run.map {
+      case ((_, context), a) => f(toHeaders.fromContext(context), a)
+    }
+
+    def evalMapTraceHeaders[B](f: (Map[String, String], A) => F[B])(implicit F: Bracket[F, Throwable]): Stream[F, B] =
+      evalMapTraceHeaders(ToHeaders.w3c)(f)
+    def evalMapTraceHeaders[B](
+      toHeaders: ToHeaders
+    )(f: (Map[String, String], A) => F[B])(implicit F: Bracket[F, Throwable]): Stream[F, B] =
+      stream.run.evalMap {
+        case ((ep, context), a) =>
+          ep.continue("propagate", SpanKind.Producer, context).use(_ => f(toHeaders.fromContext(context), a))
+      }
+  }
+}

--- a/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/syntax/package.scala
+++ b/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/syntax/package.scala
@@ -1,0 +1,6 @@
+package io.janstenpickle.trace4cats.fs2
+
+package object syntax {
+  object all extends Fs2StreamSyntax
+  object stream extends Fs2StreamSyntax
+}


### PR DESCRIPTION
- Support traces propagated within an FS2 stream
- Allow extraction of headers for propagation across
  service boundaries