### PR TITLE
Override toString in TraceId and SpanId

### DIFF
--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanId.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanId.scala
@@ -9,7 +9,9 @@ import org.apache.commons.codec.binary.Hex
 
 import scala.util.Try
 
-case class SpanId private (value: Array[Byte]) extends AnyVal
+case class SpanId private (value: Array[Byte]) extends AnyVal {
+  override def toString: String = show"SpanId($this)"
+}
 
 object SpanId {
   def apply[F[_]: Defer: ApplicativeError[*[_], Throwable]]: F[SpanId] =

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceId.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceId.scala
@@ -9,7 +9,10 @@ import org.apache.commons.codec.binary.Hex
 
 import scala.util.Try
 
-case class TraceId private (value: Array[Byte]) extends AnyVal
+case class TraceId private (value: Array[Byte]) extends AnyVal {
+  override def toString: String = show"TraceId($this)"
+}
+
 object TraceId {
   def apply[F[_]: Defer: ApplicativeError[*[_], Throwable]]: F[TraceId] =
     Defer[F].defer(ApplicativeError[F, Throwable].catchNonFatal {


### PR DESCRIPTION
This is to make `toString` representation of these classes useful in cases where you cannot use `Show` instances and have to rely on `.toString`.

I followed the standard template for case class stringification, thus `.toString` output differs from the one of `.show`, e.g.
`TraceId(62b4c143dc717ac2fa8d0eb578f5bcc5)` vs `62b4c143dc717ac2fa8d0eb578f5bcc5` .