### PR TITLE
Filter http4s requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -424,7 +424,10 @@ lazy val fs2 = (project in file("modules/fs2"))
 
 lazy val `http4s-common` = (project in file("modules/http4s-common"))
   .settings(publishSettings)
-  .settings(name := "trace4cats-http4s-common", libraryDependencies ++= Seq(Dependencies.http4sServer))
+  .settings(
+    name := "trace4cats-http4s-common",
+    libraryDependencies ++= Seq(Dependencies.http4sServer, Dependencies.http4sDsl)
+  )
   .dependsOn(model)
 
 lazy val `sttp-client` = (project in file("modules/sttp-client"))
@@ -486,8 +489,7 @@ lazy val `http4s-server` = (project in file("modules/http4s-server"))
     libraryDependencies ++= Seq(Dependencies.http4sServer),
     libraryDependencies ++= (Dependencies.test ++ Seq(
       Dependencies.http4sBlazeClient,
-      Dependencies.http4sBlazeServer,
-      Dependencies.http4sDsl
+      Dependencies.http4sBlazeServer
     )).map(_ % Test)
   )
   .dependsOn(model, kernel, core, inject, `http4s-common`, `exporter-common` % "test->compile")

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/AllCompleters.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/AllCompleters.scala
@@ -38,8 +38,7 @@ object AllCompleters {
       OpenTelemetryOtlpGrpcSpanCompleter[F](process),
       OpenTelemetryOtlpHttpSpanCompleter.blazeClient[F](blocker, process),
       StackdriverGrpcSpanCompleter[F](blocker, process, "gcp-project-id-123"),
-      StackdriverHttpSpanCompleter
-        .blazeClient[F](blocker, process, "gcp-project-id-123", "/path/to/service-account.json")
+      StackdriverHttpSpanCompleter.blazeClient[F](blocker, process)
     ).parSequence.map { completers =>
       (LogSpanCompleter[F] :: completers).combineAll
     }

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Http4sExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Http4sExample.scala
@@ -7,6 +7,7 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.example.Fs2Example.entryPoint
 import io.janstenpickle.trace4cats.http4s.client.syntax._
+import io.janstenpickle.trace4cats.http4s.common.Http4sRequestFilter
 import io.janstenpickle.trace4cats.http4s.server.syntax._
 import io.janstenpickle.trace4cats.model.TraceProcess
 import org.http4s.HttpRoutes
@@ -39,7 +40,7 @@ object Http4sExample extends IOApp {
 
       server <- BlazeServerBuilder[IO](blocker.blockingContext)
         .bindHttp(8080, "0.0.0.0")
-        .withHttpApp(routes.inject(ep).orNotFound) // use implicit syntax to inject an entry point to http routes
+        .withHttpApp(routes.inject(ep, requestFilter = Http4sRequestFilter.kubernetesPrometheus).orNotFound) // use implicit syntax to inject an entry point to http routes
         .resource
     } yield server).use { _ =>
       IO(ExitCode.Success)

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Http4sZioExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Http4sZioExample.scala
@@ -5,6 +5,7 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.janstenpickle.trace4cats.example.Fs2Example.entryPoint
 import io.janstenpickle.trace4cats.http4s.client.zio.syntax._
+import io.janstenpickle.trace4cats.http4s.common.Http4sRequestFilter
 import io.janstenpickle.trace4cats.http4s.server.zio.syntax._
 import io.janstenpickle.trace4cats.inject.zio._
 import io.janstenpickle.trace4cats.model.TraceProcess
@@ -40,7 +41,7 @@ object Http4sZioExample extends CatsApp {
 
       server <- BlazeServerBuilder[Task](blocker.blockingContext)
         .bindHttp(8080, "0.0.0.0")
-        .withHttpApp(routes.inject(ep).orNotFound) // use implicit syntax to inject an entry point to http routes
+        .withHttpApp(routes.inject(ep, requestFilter = Http4sRequestFilter.kubernetesPrometheus).orNotFound) // use implicit syntax to inject an entry point to http routes
         .resource
     } yield server)
       .use { _ =>

--- a/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sRequestFilter.scala
+++ b/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sRequestFilter.scala
@@ -1,0 +1,29 @@
+package io.janstenpickle.trace4cats.http4s.common
+
+import org.http4s.Uri
+import org.http4s.dsl.Http4sDsl
+
+object Http4sRequestFilter extends Http4sDsl[AnyK] {
+  val allowAll: Http4sRequestFilter = {
+    case _ => true
+  }
+
+  val kubernetes: Http4sRequestFilter = {
+    case GET -> Root / "liveness" => false
+    case GET -> Root / "healthcheck" => false
+  }
+
+  val prometheus: Http4sRequestFilter = {
+    case GET -> Root / "metrics" => false
+  }
+
+  val kubernetesPrometheus: Http4sRequestFilter = kubernetes.orElse(prometheus)
+
+  def fullPaths(first: String, others: String*): Http4sRequestFilter = {
+    val paths: Set[String] = Set(first) ++ others
+
+    {
+      case req => !paths.contains(Uri.decode(req.uri.path))
+    }
+  }
+}

--- a/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sRequestFilter.scala
+++ b/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sRequestFilter.scala
@@ -3,7 +3,10 @@ package io.janstenpickle.trace4cats.http4s.common
 import org.http4s.Uri
 import org.http4s.dsl.Http4sDsl
 
-object Http4sRequestFilter extends Http4sDsl[AnyK] {
+object Http4sRequestFilter {
+  private object dsl extends Http4sDsl[AnyK]
+  import dsl._
+
   val allowAll: Http4sRequestFilter = {
     case _ => true
   }

--- a/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/package.scala
+++ b/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/package.scala
@@ -10,4 +10,6 @@ package object common {
     * may be used to get a `String` from a `Request[F]`.
     */
   type Http4sSpanNamer = Request[AnyK] => String
+
+  type Http4sRequestFilter = PartialFunction[Request[AnyK], Boolean]
 }

--- a/modules/http4s-server-zio/src/main/scala/io/janstenpickle/trace4cats/http4s/server/zio/ServerSyntax.scala
+++ b/modules/http4s-server-zio/src/main/scala/io/janstenpickle/trace4cats/http4s/server/zio/ServerSyntax.scala
@@ -1,7 +1,7 @@
 package io.janstenpickle.trace4cats.http4s.server.zio
 
 import cats.~>
-import io.janstenpickle.trace4cats.http4s.common.Http4sSpanNamer
+import io.janstenpickle.trace4cats.http4s.common.{Http4sRequestFilter, Http4sSpanNamer}
 import io.janstenpickle.trace4cats.http4s.server.ServerTracer
 import io.janstenpickle.trace4cats.inject.EntryPoint
 import io.janstenpickle.trace4cats.inject.zio.ZIOTrace
@@ -15,6 +15,7 @@ trait ServerSyntax {
     def inject(
       entryPoint: EntryPoint[Task],
       spanNamer: Http4sSpanNamer = Http4sSpanNamer.methodWithPath,
+      requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     ): HttpRoutes[Task] =
       ServerTracer.injectRoutes[Task, ZIOTrace](
@@ -23,6 +24,7 @@ trait ServerSyntax {
         λ[Task ~> ZIOTrace](fa => fa),
         span => λ[ZIOTrace ~> Task](_.provide(span)),
         spanNamer,
+        requestFilter,
         dropHeadersWhen
       )
   }
@@ -31,6 +33,7 @@ trait ServerSyntax {
     def inject(
       entryPoint: EntryPoint[Task],
       spanNamer: Http4sSpanNamer = Http4sSpanNamer.methodWithPath,
+      requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     ): HttpApp[Task] =
       ServerTracer.injectApp[Task, ZIOTrace](
@@ -39,6 +42,7 @@ trait ServerSyntax {
         λ[Task ~> ZIOTrace](fa => fa),
         span => λ[ZIOTrace ~> Task](_.provide(span)),
         spanNamer,
+        requestFilter,
         dropHeadersWhen
       )
   }

--- a/modules/http4s-server-zio/src/test/scala/io/janstenpickle/trace4cats/http4s/server/zio/ServerSyntaxSpec.scala
+++ b/modules/http4s-server-zio/src/test/scala/io/janstenpickle/trace4cats/http4s/server/zio/ServerSyntaxSpec.scala
@@ -13,7 +13,7 @@ class ServerSyntaxSpec
       9084,
       λ[Task ~> Id](fa => Runtime.default.unsafeRun(fa)),
       span => λ[ZIOTrace ~> Task](_.provide(span)),
-      _.inject(_),
-      _.inject(_),
+      (routes, filter, ep) => routes.inject(ep, requestFilter = filter),
+      (app, filter, ep) => app.inject(ep, requestFilter = filter),
       Timer[Task]
     )

--- a/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntax.scala
+++ b/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntax.scala
@@ -4,7 +4,7 @@ import cats.data.Kleisli
 import cats.effect.Bracket
 import cats.~>
 import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.http4s.common.Http4sSpanNamer
+import io.janstenpickle.trace4cats.http4s.common.{Http4sRequestFilter, Http4sSpanNamer}
 import io.janstenpickle.trace4cats.inject.EntryPoint
 import org.http4s._
 import org.http4s.util.CaseInsensitiveString
@@ -14,6 +14,7 @@ trait ServerSyntax {
     def inject(
       entryPoint: EntryPoint[F],
       spanNamer: Http4sSpanNamer = Http4sSpanNamer.methodWithPath,
+      requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     )(implicit F: Bracket[F, Throwable]): HttpRoutes[F] = {
       type G[A] = Kleisli[F, Span[F], A]
@@ -24,6 +25,7 @@ trait ServerSyntax {
         λ[F ~> G](fa => Kleisli(_ => fa)),
         span => λ[G ~> F](_(span)),
         spanNamer,
+        requestFilter,
         dropHeadersWhen
       )
     }
@@ -33,6 +35,7 @@ trait ServerSyntax {
     def inject(
       entryPoint: EntryPoint[F],
       spanNamer: Http4sSpanNamer = Http4sSpanNamer.methodWithPath,
+      requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     )(implicit F: Bracket[F, Throwable]): HttpApp[F] = {
       type G[A] = Kleisli[F, Span[F], A]
@@ -43,6 +46,7 @@ trait ServerSyntax {
         λ[F ~> G](fa => Kleisli(_ => fa)),
         span => λ[G ~> F](_(span)),
         spanNamer,
+        requestFilter,
         dropHeadersWhen
       )
     }

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
@@ -13,7 +13,7 @@ class ServerSyntaxSpec
       9082,
       λ[IO ~> Id](_.unsafeRunSync()),
       span => λ[Kleisli[IO, Span[IO], *] ~> IO](_(span)),
-      _.inject(_),
-      _.inject(_),
+      (routes, filter, ep) => routes.inject(ep, requestFilter = filter),
+      (app, filter, ep) => app.inject(ep, requestFilter = filter),
       IO.timer(ExecutionContext.global)
     )


### PR DESCRIPTION
Allow http4s requests to be filtered and therefore
exempt from tracing. This maybe useful for utility
endpoints such as for k8s and prometheus.