### PR TITLE
Deferred attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ Instrumentation for trace propagation and continuation is available for the foll
 - [FS2 Kafka] consumer and producer
 - [FS2]
 
+**Unlike other tracing libraries, trace attributes are lazily evaluated. If a span is not [sampled](docs/sampling.md),
+no computation associated with calculating attribute values will be performed** 
+
 For more information on how to use these can be found in the [examples documentation](docs/examples.md)
 
 ## Quickstart
 
-** For more see the [documentation](#documentation) for more advanced [examples](docs/examples.md) **
+**For more see the [documentation](#documentation) for more advanced [examples](docs/examples.md)**
 
 Add the following dependencies to your `build.sbt`:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,6 +48,20 @@ The following implementations are provided out of the box:
 - Probabilistic
 - Rate
 
+#### `AttributeValue`
+
+An ADT for representing different types of span attributes, currently supports the following types as single values or
+as lists.
+
+- String
+- Boolean
+- Double
+- Long
+
+Unlike many other tracing libraries, `AttributeValue`s are lazily evaluated, so if a span is not sampled the value will
+not be computed. This is especially useful when a value requires some computation before it can be displayed, such as
+the size of a collection.
+
 #### `ToHeaders`
 
 Convert a span context to and from message or http headers.

--- a/modules/avro/src/main/scala/io/janstenpickle/trace4cats/avro/AvroInstances.scala
+++ b/modules/avro/src/main/scala/io/janstenpickle/trace4cats/avro/AvroInstances.scala
@@ -1,8 +1,8 @@
 package io.janstenpickle.trace4cats.avro
 
-import cats.ApplicativeError
 import cats.data.NonEmptyList
 import cats.syntax.either._
+import cats.{ApplicativeError, Eval}
 import io.janstenpickle.trace4cats.model._
 import org.apache.avro.Schema
 import vulcan.generic._
@@ -34,6 +34,13 @@ object AvroInstances {
   implicit val parentCodec: Codec[Parent] = Codec.derive
 
   implicit val spanContextCodec: Codec[SpanContext] = Codec.derive
+
+  implicit def evalCodec[A: Codec]: Codec[Eval[A]] =
+    Codec.instance(
+      Codec[A].schema,
+      a => Codec[A].encode(a.value),
+      (obj, schema) => Codec[A].decode(obj, schema).map(Eval.later(_))
+    )
 
   implicit val traceValueCodec: Codec[AttributeValue] = Codec.derive[AttributeValue]
 

--- a/modules/collector-common/src/main/scala-2.13/io/janstenpickle/trace4cats/collector/common/config/CommonCollectorConfig.scala
+++ b/modules/collector-common/src/main/scala-2.13/io/janstenpickle/trace4cats/collector/common/config/CommonCollectorConfig.scala
@@ -1,5 +1,6 @@
 package io.janstenpickle.trace4cats.collector.common.config
 
+import cats.Eval
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
 import cats.syntax.functor._
 import io.circe.Decoder
@@ -136,14 +137,14 @@ case class FilteringConfig(
 )
 object FilteringConfig {
   implicit val attributeValueDecoder: Decoder[AttributeValue] = List[Decoder[AttributeValue]](
-    Decoder.decodeBoolean.map(AttributeValue.BooleanValue).widen,
-    Decoder.decodeDouble.map(AttributeValue.DoubleValue).widen,
-    Decoder.decodeLong.map(AttributeValue.LongValue).widen,
-    Decoder.decodeString.map(AttributeValue.StringValue).widen,
-    Decoder[NonEmptyList[Boolean]].map(AttributeValue.BooleanList).widen,
-    Decoder[NonEmptyList[Double]].map(AttributeValue.DoubleList).widen,
-    Decoder[NonEmptyList[Long]].map(AttributeValue.LongList).widen,
-    Decoder[NonEmptyList[String]].map(AttributeValue.StringList).widen
+    Decoder.decodeBoolean.map(v => AttributeValue.BooleanValue(Eval.now(v))).widen,
+    Decoder.decodeDouble.map(v => AttributeValue.DoubleValue(Eval.now(v))).widen,
+    Decoder.decodeLong.map(v => AttributeValue.LongValue(Eval.now(v))).widen,
+    Decoder.decodeString.map(v => AttributeValue.StringValue(Eval.now(v))).widen,
+    Decoder[NonEmptyList[Boolean]].map(v => AttributeValue.BooleanList(Eval.now(v))).widen,
+    Decoder[NonEmptyList[Double]].map(v => AttributeValue.DoubleList(Eval.now(v))).widen,
+    Decoder[NonEmptyList[Long]].map(v => AttributeValue.LongList(Eval.now(v))).widen,
+    Decoder[NonEmptyList[String]].map(v => AttributeValue.StringList(Eval.now(v))).widen
   ).reduceLeft(_.or(_))
 
   implicit val decoder: Decoder[FilteringConfig] = deriveConfiguredDecoder

--- a/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpan.scala
+++ b/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpan.scala
@@ -54,18 +54,18 @@ object DataDogSpan {
           span.serviceName,
           allAttributes.get("resource.name").fold(span.serviceName)(_.toString),
           allAttributes.collect {
-            case (k, AttributeValue.StringValue(value)) => k -> value
-            case (k, AttributeValue.BooleanValue(value)) if k != "error" => k -> value.toString
+            case (k, AttributeValue.StringValue(value)) => k -> value.value
+            case (k, AttributeValue.BooleanValue(value)) if k != "error" => k -> value.value.toString
             case (k, value: AttributeValue.AttributeList) => k -> value.show
           },
           allAttributes.collect {
-            case (k, AttributeValue.DoubleValue(value)) => k -> value
-            case (k, AttributeValue.LongValue(value)) => k -> value.toDouble
+            case (k, AttributeValue.DoubleValue(value)) => k -> value.value
+            case (k, AttributeValue.LongValue(value)) => k -> value.value.toDouble
           },
           startNanos,
           TimeUnit.MILLISECONDS.toNanos(span.end.toEpochMilli) - startNanos,
           allAttributes.get("error").map {
-            case AttributeValue.BooleanValue(true) => 1
+            case AttributeValue.BooleanValue(v) if v.value => 1
             case _ => 0
           }
         )

--- a/modules/jaeger-integration-test/src/main/scala/io/janstenpickle/trace4cats/test/jaeger/BaseJaegerSpec.scala
+++ b/modules/jaeger-integration-test/src/main/scala/io/janstenpickle/trace4cats/test/jaeger/BaseJaegerSpec.scala
@@ -45,10 +45,10 @@ trait BaseJaegerSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks wit
   ): List[JaegerTraceResponse] = {
     def convertAttributes(attributes: Map[String, AttributeValue]): List[JaegerTag] =
       attributes.toList.map {
-        case (k, AttributeValue.StringValue(value)) => JaegerTag.StringTag(k, value)
-        case (k, AttributeValue.BooleanValue(value)) => JaegerTag.BoolTag(k, value)
-        case (k, AttributeValue.DoubleValue(value)) => JaegerTag.FloatTag(k, value)
-        case (k, AttributeValue.LongValue(value)) => JaegerTag.LongTag(k, value)
+        case (k, AttributeValue.StringValue(value)) => JaegerTag.StringTag(k, value.value)
+        case (k, AttributeValue.BooleanValue(value)) => JaegerTag.BoolTag(k, value.value)
+        case (k, AttributeValue.DoubleValue(value)) => JaegerTag.FloatTag(k, value.value)
+        case (k, AttributeValue.LongValue(value)) => JaegerTag.LongTag(k, value.value)
         case (k, v: AttributeValue.AttributeList) => JaegerTag.StringTag(k, v.show)
       }
 

--- a/modules/jaeger-thrift-exporter/src/main/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporter.scala
+++ b/modules/jaeger-thrift-exporter/src/main/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporter.scala
@@ -45,13 +45,13 @@ object JaegerSpanExporter {
       attributes.view
         .map {
           case (key, StringValue(value)) =>
-            new Tag(key, TagType.STRING).setVStr(value)
+            new Tag(key, TagType.STRING).setVStr(value.value)
           case (key, DoubleValue(value)) =>
-            new Tag(key, TagType.DOUBLE).setVDouble(value)
+            new Tag(key, TagType.DOUBLE).setVDouble(value.value)
           case (key, BooleanValue(value)) =>
-            new Tag(key, TagType.BOOL).setVBool(value)
+            new Tag(key, TagType.BOOL).setVBool(value.value)
           case (key, LongValue(value)) =>
-            new Tag(key, TagType.LONG).setVLong(value)
+            new Tag(key, TagType.LONG).setVLong(value.value)
           case (key, value: AttributeList) =>
             new Tag(key, TagType.STRING).setVStr(value.show)
         }

--- a/modules/meta/src/test/scala/io/janstenpickle/trace4cats/meta/PipeTracerSpec.scala
+++ b/modules/meta/src/test/scala/io/janstenpickle/trace4cats/meta/PipeTracerSpec.scala
@@ -1,5 +1,6 @@
 package io.janstenpickle.trace4cats.meta
 
+import cats.Eq
 import cats.effect.{ContextShift, IO, Timer}
 import fs2.{Chunk, Stream}
 import io.chrisdavenport.log4cats.Logger
@@ -29,11 +30,16 @@ class PipeTracerSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenProp
 
       spans.size should be(batch.spans.size + 1)
 
-      metaSpan.allAttributes should contain theSameElementsAs (process.attributes ++ Map[String, AttributeValue](
-        "trace4cats.version" -> BuildInfo.version,
-        "batch.size" -> batch.spans.size,
-        "service.name" -> process.serviceName
-      ) ++ attributes)
+      assert(
+        Eq.eqv(
+          metaSpan.allAttributes,
+          process.attributes ++ Map[String, AttributeValue](
+            "trace4cats.version" -> BuildInfo.version,
+            "batch.size" -> batch.spans.size,
+            "service.name" -> process.serviceName
+          ) ++ attributes
+        )
+      )
       metaSpan.kind should be(SpanKind.Consumer)
     }
   )

--- a/modules/meta/src/test/scala/io/janstenpickle/trace4cats/meta/TracedSpanCompleterSpec.scala
+++ b/modules/meta/src/test/scala/io/janstenpickle/trace4cats/meta/TracedSpanCompleterSpec.scala
@@ -1,5 +1,6 @@
 package io.janstenpickle.trace4cats.meta
 
+import cats.Eq
 import cats.effect.{ContextShift, IO, Timer}
 import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
 import io.janstenpickle.trace4cats.kernel.{BuildInfo, SpanSampler}
@@ -33,11 +34,16 @@ class TracedSpanCompleterSpec
 
         spans.size should be(2)
 
-        metaSpan.allAttributes should contain theSameElementsAs (process.attributes ++ Map[String, AttributeValue](
-          "completer.name" -> completerName,
-          "trace4cats.version" -> BuildInfo.version,
-          "service.name" -> process.serviceName
-        ))
+        assert(
+          Eq.eqv(
+            metaSpan.allAttributes,
+            process.attributes ++ Map[String, AttributeValue](
+              "completer.name" -> completerName,
+              "trace4cats.version" -> BuildInfo.version,
+              "service.name" -> process.serviceName
+            )
+          )
+        )
         metaSpan.kind should be(SpanKind.Producer)
         completedSpan.metaTrace should be(Some(MetaTrace(metaSpan.context.traceId, metaSpan.context.spanId)))
 

--- a/modules/meta/src/test/scala/io/janstenpickle/trace4cats/meta/TracedSpanExporterSpec.scala
+++ b/modules/meta/src/test/scala/io/janstenpickle/trace4cats/meta/TracedSpanExporterSpec.scala
@@ -1,5 +1,6 @@
 package io.janstenpickle.trace4cats.meta
 
+import cats.Eq
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import fs2.{Chunk, Stream}
 import fs2.concurrent.Queue
@@ -34,12 +35,17 @@ class TracedSpanExporterSpec
 
       spans.size should be(batch.spans.size + 1)
 
-      metaSpan.allAttributes should contain theSameElementsAs (process.attributes ++ Map[String, AttributeValue](
-        "exporter.name" -> exporterName,
-        "trace4cats.version" -> BuildInfo.version,
-        "batch.size" -> batch.spans.size,
-        "service.name" -> process.serviceName
-      ) ++ attributes)
+      assert(
+        Eq.eqv(
+          metaSpan.allAttributes,
+          process.attributes ++ Map[String, AttributeValue](
+            "exporter.name" -> exporterName,
+            "trace4cats.version" -> BuildInfo.version,
+            "batch.size" -> batch.spans.size,
+            "service.name" -> process.serviceName
+          ) ++ attributes
+        )
+      )
       metaSpan.kind should be(SpanKind.Producer)
     }
   )

--- a/modules/model/src/test/scala/io/janstenpickle/trace4cats/model/AttributeValueSpec.scala
+++ b/modules/model/src/test/scala/io/janstenpickle/trace4cats/model/AttributeValueSpec.scala
@@ -1,7 +1,8 @@
 package io.janstenpickle.trace4cats.model
 
+import cats.Eval
 import cats.kernel.laws.discipline.SemigroupTests
-import org.scalacheck.ScalacheckShapeless
+import org.scalacheck.{Arbitrary, ScalacheckShapeless}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
@@ -11,6 +12,8 @@ class AttributeValueSpec
     with ScalaCheckDrivenPropertyChecks
     with FunSuiteDiscipline
     with ScalacheckShapeless {
+
+  implicit def evalArb[A: Arbitrary]: Arbitrary[Eval[A]] = Arbitrary(Arbitrary.arbitrary[A].map(Eval.now))
 
   checkAll("AttributeValue semigroup", SemigroupTests[AttributeValue].semigroup)
 }

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/Trace4CatsConversions.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/Trace4CatsConversions.scala
@@ -39,10 +39,10 @@ trait Trace4CatsConversions {
       override def put(key: String, value: AttributeValue): F[Unit] = putAll(key -> value)
       override def putAll(fields: (String, AttributeValue)*): F[Unit] =
         trace.put(fields.map {
-          case (k, StringValue(v)) => k -> V.StringValue(v)
-          case (k, DoubleValue(v)) => k -> V.NumberValue(v)
-          case (k, LongValue(v)) => k -> V.NumberValue(v)
-          case (k, BooleanValue(v)) => k -> V.BooleanValue(v)
+          case (k, StringValue(v)) => k -> V.StringValue(v.value)
+          case (k, DoubleValue(v)) => k -> V.NumberValue(v.value)
+          case (k, LongValue(v)) => k -> V.NumberValue(v.value)
+          case (k, BooleanValue(v)) => k -> V.BooleanValue(v.value)
           case (k, StringList(v)) => k -> V.StringValue(v.toString())
           case (k, BooleanList(v)) => k -> V.StringValue(v.toString())
           case (k, DoubleList(v)) => k -> V.StringValue(v.toString())

--- a/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/Convert.scala
+++ b/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/Convert.scala
@@ -14,10 +14,10 @@ import scala.collection.mutable.ListBuffer
 // https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api
 object Convert {
   implicit val traceValueEncoder: Encoder[AttributeValue] = Encoder.instance {
-    case AttributeValue.StringValue(value) => Json.fromString(value)
-    case AttributeValue.BooleanValue(value) => Json.fromBoolean(value)
-    case AttributeValue.LongValue(value) => Json.fromLong(value)
-    case AttributeValue.DoubleValue(value) => Json.fromDoubleOrString(value)
+    case AttributeValue.StringValue(value) => Json.fromString(value.value)
+    case AttributeValue.BooleanValue(value) => Json.fromBoolean(value.value)
+    case AttributeValue.LongValue(value) => Json.fromLong(value.value)
+    case AttributeValue.DoubleValue(value) => Json.fromDoubleOrString(value.value)
     case value: AttributeValue.AttributeList => Json.fromString(value.show)
   }
 

--- a/modules/opentelemetry-common/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/common/Trace4CatsReadableAttributes.scala
+++ b/modules/opentelemetry-common/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/common/Trace4CatsReadableAttributes.scala
@@ -13,19 +13,22 @@ object Trace4CatsReadableAttributes {
       override def get[T](key: AttributeKey[T]): T = {
 
         (key.getType match {
-          case AttributeType.STRING => map.get(key.getKey).collect { case StringValue(value) => value.asInstanceOf[T] }
+          case AttributeType.STRING =>
+            map.get(key.getKey).collect { case StringValue(value) => value.value.asInstanceOf[T] }
           case AttributeType.BOOLEAN =>
-            map.get(key.getKey).collect { case BooleanValue(value) => value.asInstanceOf[T] }
-          case AttributeType.LONG => map.get(key.getKey).collect { case LongValue(value) => value.asInstanceOf[T] }
-          case AttributeType.DOUBLE => map.get(key.getKey).collect { case DoubleValue(value) => value.asInstanceOf[T] }
+            map.get(key.getKey).collect { case BooleanValue(value) => value.value.asInstanceOf[T] }
+          case AttributeType.LONG =>
+            map.get(key.getKey).collect { case LongValue(value) => value.value.asInstanceOf[T] }
+          case AttributeType.DOUBLE =>
+            map.get(key.getKey).collect { case DoubleValue(value) => value.value.asInstanceOf[T] }
           case AttributeType.STRING_ARRAY =>
-            map.get(key.getKey).collect { case StringList(value) => value.toList.asJava.asInstanceOf[T] }
+            map.get(key.getKey).collect { case StringList(value) => value.value.toList.asJava.asInstanceOf[T] }
           case AttributeType.BOOLEAN_ARRAY =>
-            map.get(key.getKey).collect { case BooleanList(value) => value.toList.asJava.asInstanceOf[T] }
+            map.get(key.getKey).collect { case BooleanList(value) => value.value.toList.asJava.asInstanceOf[T] }
           case AttributeType.LONG_ARRAY =>
-            map.get(key.getKey).collect { case LongList(value) => value.toList.asJava.asInstanceOf[T] }
+            map.get(key.getKey).collect { case LongList(value) => value.value.toList.asJava.asInstanceOf[T] }
           case AttributeType.DOUBLE_ARRAY =>
-            map.get(key.getKey).collect { case DoubleList(value) => value.toList.asJava.asInstanceOf[T] }
+            map.get(key.getKey).collect { case DoubleList(value) => value.value.toList.asJava.asInstanceOf[T] }
         }).get
       }
 
@@ -36,29 +39,29 @@ object Trace4CatsReadableAttributes {
       override def forEach(consumer: AttributeConsumer): Unit =
         map.foreach { case (k, v) =>
           v match {
-            case StringValue(value) => consumer.consume[java.lang.String](AttributeKey.stringKey(k), value)
-            case BooleanValue(value) => consumer.consume[java.lang.Boolean](AttributeKey.booleanKey(k), value)
-            case DoubleValue(value) => consumer.consume[java.lang.Double](AttributeKey.doubleKey(k), value)
-            case LongValue(value) => consumer.consume[java.lang.Long](AttributeKey.longKey(k), value)
+            case StringValue(value) => consumer.consume[java.lang.String](AttributeKey.stringKey(k), value.value)
+            case BooleanValue(value) => consumer.consume[java.lang.Boolean](AttributeKey.booleanKey(k), value.value)
+            case DoubleValue(value) => consumer.consume[java.lang.Double](AttributeKey.doubleKey(k), value.value)
+            case LongValue(value) => consumer.consume[java.lang.Long](AttributeKey.longKey(k), value.value)
             case StringList(value) =>
               consumer.consume[java.util.List[java.lang.String]](
                 AttributeKey.stringArrayKey(k),
-                value.toList.asJava.asInstanceOf[java.util.List[java.lang.String]]
+                value.value.toList.asJava.asInstanceOf[java.util.List[java.lang.String]]
               )
             case BooleanList(value) =>
               consumer.consume[java.util.List[java.lang.Boolean]](
                 AttributeKey.booleanArrayKey(k),
-                value.toList.asJava.asInstanceOf[java.util.List[java.lang.Boolean]]
+                value.value.toList.asJava.asInstanceOf[java.util.List[java.lang.Boolean]]
               )
             case DoubleList(value) =>
               consumer.consume[java.util.List[java.lang.Double]](
                 AttributeKey.doubleArrayKey(k),
-                value.toList.asJava.asInstanceOf[java.util.List[java.lang.Double]]
+                value.value.toList.asJava.asInstanceOf[java.util.List[java.lang.Double]]
               )
             case LongList(value) =>
               consumer.consume[java.util.List[java.lang.Long]](
                 AttributeKey.longArrayKey(k),
-                value.toList.asJava.asInstanceOf[java.util.List[java.lang.Long]]
+                value.value.toList.asJava.asInstanceOf[java.util.List[java.lang.Long]]
               )
           }
         }

--- a/modules/opentelemetry-otlp-http-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/Convert.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/Convert.scala
@@ -27,13 +27,13 @@ object Convert {
   def toAttributes(attributes: Map[String, AttributeValue]): List[KeyValue] =
     attributes.toList.map {
       case (k, AttributeValue.StringValue(v)) =>
-        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.StringValue(v))))
+        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.StringValue(v.value))))
       case (k, AttributeValue.BooleanValue(v)) =>
-        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.BoolValue(v))))
+        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.BoolValue(v.value))))
       case (k, AttributeValue.DoubleValue(v)) =>
-        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.DoubleValue(v))))
+        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.DoubleValue(v.value))))
       case (k, AttributeValue.LongValue(v)) =>
-        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.IntValue(v))))
+        KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.IntValue(v.value))))
       case (k, v: AttributeValue.AttributeList) =>
         KeyValue(key = k, value = Some(AnyValue.of(AnyValue.Value.StringValue(v.show))))
     }

--- a/modules/stackdriver-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverGrpcSpanExporter.scala
+++ b/modules/stackdriver-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverGrpcSpanExporter.scala
@@ -5,9 +5,9 @@ import java.time.Instant
 import cats.Foldable
 import cats.data.NonEmptyList
 import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync, Timer}
+import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.syntax.show._
-import cats.syntax.foldable._
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.Credentials
 import com.google.auth.oauth2.GoogleCredentials
@@ -73,10 +73,11 @@ object StackdriverGrpcSpanExporter {
             k,
             (v match {
               case AttributeValue.StringValue(value) =>
-                GAttributeValue.newBuilder().setStringValue(toTruncatableStringProto(value))
-              case AttributeValue.BooleanValue(value) => GAttributeValue.newBuilder().setBoolValue(value)
-              case AttributeValue.DoubleValue(value) => GAttributeValue.newBuilder().setIntValue(value.toLong)
-              case AttributeValue.LongValue(value) => GAttributeValue.newBuilder().setIntValue(value)
+                GAttributeValue.newBuilder().setStringValue(toTruncatableStringProto(value.value))
+              case AttributeValue.BooleanValue(value) => GAttributeValue.newBuilder().setBoolValue(value.value)
+              case AttributeValue.DoubleValue(value) =>
+                GAttributeValue.newBuilder().setStringValue(toTruncatableStringProto(value.value.show))
+              case AttributeValue.LongValue(value) => GAttributeValue.newBuilder().setIntValue(value.value)
               case vs: AttributeValue.AttributeList =>
                 GAttributeValue.newBuilder().setStringValue(toTruncatableStringProto(vs.show))
             }).build()

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/strackdriver/model/Attributes.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/strackdriver/model/Attributes.scala
@@ -10,10 +10,10 @@ case class Attributes(attributeMap: Map[String, SDAttributeValue], droppedAttrib
 object Attributes {
   def fromCompleted(attributes: Map[String, AttributeValue]): Attributes = {
     val attrs = attributes.take(32).map {
-      case (k, AttributeValue.StringValue(value)) => k -> SDAttributeValue.StringValue(value)
-      case (k, AttributeValue.DoubleValue(value)) => k -> SDAttributeValue.StringValue(value.toString)
-      case (k, AttributeValue.BooleanValue(value)) => k -> SDAttributeValue.BoolValue(value)
-      case (k, AttributeValue.LongValue(value)) => k -> SDAttributeValue.IntValue(value)
+      case (k, AttributeValue.StringValue(value)) => k -> SDAttributeValue.StringValue(value.value)
+      case (k, AttributeValue.DoubleValue(value)) => k -> SDAttributeValue.StringValue(value.value.toString)
+      case (k, AttributeValue.BooleanValue(value)) => k -> SDAttributeValue.BoolValue(value.value)
+      case (k, AttributeValue.LongValue(value)) => k -> SDAttributeValue.IntValue(value.value)
       case (k, v: AttributeValue.AttributeList) => k -> SDAttributeValue.StringValue(v.show)
     }
 

--- a/modules/test/src/main/scala/io/janstenpickle/trace4cats/test/ArbitraryInstances.scala
+++ b/modules/test/src/main/scala/io/janstenpickle/trace4cats/test/ArbitraryInstances.scala
@@ -2,6 +2,7 @@ package io.janstenpickle.trace4cats.test
 
 import java.time.Instant
 
+import cats.Eval
 import fs2.Chunk
 import io.janstenpickle.trace4cats.model._
 import org.scalacheck.{Arbitrary, Gen, ScalacheckShapeless}
@@ -40,6 +41,8 @@ trait ArbitraryInstances extends ScalacheckShapeless {
         TraceState(kvs.toMap).get
       }
   )
+
+  implicit def evalArb[A: Arbitrary]: Arbitrary[Eval[A]] = Arbitrary(Arbitrary.arbitrary[A].map(Eval.later(_)))
 
   implicit val batchArb: Arbitrary[Batch[Chunk]] = Arbitrary(for {
     size <- Gen.choose(1, 3)


### PR DESCRIPTION
Make the evaluation of attributes deferred.
This means that for spans where the sample decision
is "drop" attribute values will not be evaluated.
This is especially useful for operations that measure
the size of collections or some other traversal.