### PR TITLE
TraceHeaders wrapper and converters for integrations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -526,7 +526,7 @@ lazy val `sttp-client` = (project in file("modules/sttp-client"))
       Dependencies.sttpHttp4s
     )).map(_ % Test)
   )
-  .dependsOn(model, kernel, core, inject, `exporter-common` % "test->compile")
+  .dependsOn(model, kernel, core, inject, `exporter-common` % "test->compile", `http4s-common` % "test->compile")
 
 lazy val `http4s-client` = (project in file("modules/http4s-client"))
   .settings(publishSettings)

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/B3SingleToHeaders.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/B3SingleToHeaders.scala
@@ -6,8 +6,8 @@ import io.janstenpickle.trace4cats.model._
 private[trace4cats] class B3SingleToHeaders extends ToHeaders {
   final val traceHeader = "b3"
 
-  override def toContext(headers: Map[String, String]): Option[SpanContext] =
-    headers.get(traceHeader).map(_.split('-').toList) match {
+  override def toContext(headers: TraceHeaders): Option[SpanContext] =
+    headers.values.get(traceHeader).map(_.split('-').toList) match {
       case Some(traceIdHex :: spanIdHex :: rest) =>
         for {
           traceId <- TraceId.fromHexString(traceIdHex)
@@ -25,7 +25,7 @@ private[trace4cats] class B3SingleToHeaders extends ToHeaders {
       case _ => None
     }
 
-  override def fromContext(context: SpanContext): Map[String, String] = {
+  override def fromContext(context: SpanContext): TraceHeaders = {
     val sampled = context.traceFlags.sampled match {
       case SampleDecision.Drop => "0"
       case SampleDecision.Include => "1"
@@ -33,9 +33,9 @@ private[trace4cats] class B3SingleToHeaders extends ToHeaders {
 
     val header = show"${context.traceId}-${context.spanId}-$sampled"
 
-    Map(traceHeader -> context.parent.fold(header) { parent =>
+    TraceHeaders(Map(traceHeader -> context.parent.fold(header) { parent =>
       show"$header-${parent.spanId}"
-    })
+    }))
   }
 
 }

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/B3SingleToHeaders.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/B3SingleToHeaders.scala
@@ -33,9 +33,9 @@ private[trace4cats] class B3SingleToHeaders extends ToHeaders {
 
     val header = show"${context.traceId}-${context.spanId}-$sampled"
 
-    TraceHeaders(Map(traceHeader -> context.parent.fold(header) { parent =>
+    TraceHeaders.of(traceHeader -> context.parent.fold(header) { parent =>
       show"$header-${parent.spanId}"
-    }))
+    })
   }
 
 }

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/W3cToHeaders.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/W3cToHeaders.scala
@@ -56,6 +56,6 @@ private[trace4cats] class W3cToHeaders extends ToHeaders {
       .map { case (k, v) => show"$k=$v" }
       .mkString(",")
 
-    TraceHeaders(Map(parentHeader -> traceParent, stateHeader -> traceState))
+    TraceHeaders.of(parentHeader -> traceParent, stateHeader -> traceState)
   }
 }

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/W3cToHeaders.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/W3cToHeaders.scala
@@ -7,7 +7,7 @@ private[trace4cats] class W3cToHeaders extends ToHeaders {
   final val parentHeader = "traceparent"
   final val stateHeader = "tracestate"
 
-  override def toContext(headers: Map[String, String]): Option[SpanContext] = {
+  override def toContext(headers: TraceHeaders): Option[SpanContext] = {
     def splitParent(traceParent: String): Option[(String, String, SampleDecision)] =
       traceParent.split('-').toList match {
         case _ :: traceId :: spanId :: sampled :: Nil =>
@@ -28,7 +28,7 @@ private[trace4cats] class W3cToHeaders extends ToHeaders {
       }
 
     val parseState: TraceState = (for {
-      state <- headers.get(stateHeader)
+      state <- headers.values.get(stateHeader)
       split = state.split(',')
       traceState <-
         if (split.length <= 32)
@@ -37,14 +37,14 @@ private[trace4cats] class W3cToHeaders extends ToHeaders {
     } yield traceState).getOrElse(TraceState.empty)
 
     for {
-      traceParent <- headers.get(parentHeader)
+      traceParent <- headers.values.get(parentHeader)
       (tid, sid, sampled) <- splitParent(traceParent)
       traceId <- TraceId.fromHexString(tid)
       spanId <- SpanId.fromHexString(sid)
     } yield SpanContext(traceId, spanId, None, TraceFlags(sampled), parseState, isRemote = true)
   }
 
-  override def fromContext(context: SpanContext): Map[String, String] = {
+  override def fromContext(context: SpanContext): TraceHeaders = {
     val sampled = context.traceFlags.sampled match {
       case SampleDecision.Drop => "00"
       case SampleDecision.Include => "01"
@@ -56,6 +56,6 @@ private[trace4cats] class W3cToHeaders extends ToHeaders {
       .map { case (k, v) => show"$k=$v" }
       .mkString(",")
 
-    Map(parentHeader -> traceParent, stateHeader -> traceState)
+    TraceHeaders(Map(parentHeader -> traceParent, stateHeader -> traceState))
   }
 }

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3SingleToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3SingleToHeadersSpec.scala
@@ -27,7 +27,7 @@ class B3SingleToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChe
   }
 
   it should "decode example B3 headers" in {
-    val headers = Map("b3" -> "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90")
+    val headers = TraceHeaders.of("b3" -> "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90")
 
     val expected = for {
       traceId <- TraceId.fromHexString("80f198ee56343ba864fe8b2a57d3eff7")

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3ToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3ToHeadersSpec.scala
@@ -1,7 +1,16 @@
 package io.janstenpickle.trace4cats
 
 import cats.Eq
-import io.janstenpickle.trace4cats.model.{Parent, SampleDecision, SpanContext, SpanId, TraceFlags, TraceHeaders, TraceId, TraceState}
+import io.janstenpickle.trace4cats.model.{
+  Parent,
+  SampleDecision,
+  SpanContext,
+  SpanId,
+  TraceFlags,
+  TraceHeaders,
+  TraceId,
+  TraceState
+}
 import io.janstenpickle.trace4cats.test.ArbitraryInstances
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3ToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3ToHeadersSpec.scala
@@ -1,7 +1,7 @@
 package io.janstenpickle.trace4cats
 
 import cats.Eq
-import io.janstenpickle.trace4cats.model.{Parent, SampleDecision, SpanContext, SpanId, TraceFlags, TraceId, TraceState}
+import io.janstenpickle.trace4cats.model.{Parent, SampleDecision, SpanContext, SpanId, TraceFlags, TraceHeaders, TraceId, TraceState}
 import io.janstenpickle.trace4cats.test.ArbitraryInstances
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -27,7 +27,7 @@ class B3ToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks wi
   }
 
   it should "decode example B3 headers" in {
-    val headers = Map(
+    val headers = TraceHeaders.of(
       "X-B3-TraceId" -> "80f198ee56343ba864fe8b2a57d3eff7",
       "X-B3-ParentSpanId" -> "05e3ac9a4f6e3b90",
       "X-B3-SpanId" -> "e457b5a2e4d86bd1",

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/EnvoyToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/EnvoyToHeadersSpec.scala
@@ -30,7 +30,7 @@ class EnvoyToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks
   }
 
   it should "decode example Envoy headers" in {
-    val headers = Map("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;05e3ac9a4f6e3b90;cs")
+    val headers = TraceHeaders.of("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;05e3ac9a4f6e3b90;cs")
 
     val expected = for {
       traceId <- TraceId.fromHexString("80f198ee56343ba864fe8b2a57d3eff7")
@@ -49,7 +49,7 @@ class EnvoyToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks
   }
 
   it should "decode example Envoy headers with no parent" in {
-    val headers = Map("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;0000000000000000;cs")
+    val headers = TraceHeaders.of("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;0000000000000000;cs")
 
     val expected = for {
       traceId <- TraceId.fromHexString("80f198ee56343ba864fe8b2a57d3eff7")
@@ -68,7 +68,7 @@ class EnvoyToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks
 
   it should "decode and encode example Envoy headers, passing through the envoy request ID" in {
     val reqId = UUID.randomUUID().toString
-    val headers = Map(
+    val headers = TraceHeaders.of(
       "x-request-id" -> reqId,
       "x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;0000000000000000;cs"
     )

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/EnvoyToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/EnvoyToHeadersSpec.scala
@@ -30,7 +30,8 @@ class EnvoyToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks
   }
 
   it should "decode example Envoy headers" in {
-    val headers = TraceHeaders.of("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;05e3ac9a4f6e3b90;cs")
+    val headers =
+      TraceHeaders.of("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;05e3ac9a4f6e3b90;cs")
 
     val expected = for {
       traceId <- TraceId.fromHexString("80f198ee56343ba864fe8b2a57d3eff7")
@@ -49,7 +50,8 @@ class EnvoyToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks
   }
 
   it should "decode example Envoy headers with no parent" in {
-    val headers = TraceHeaders.of("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;0000000000000000;cs")
+    val headers =
+      TraceHeaders.of("x-ot-span-context" -> "80f198ee56343ba864fe8b2a57d3eff7;e457b5a2e4d86bd1;0000000000000000;cs")
 
     val expected = for {
       traceId <- TraceId.fromHexString("80f198ee56343ba864fe8b2a57d3eff7")

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/W3cToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/W3cToHeadersSpec.scala
@@ -1,7 +1,15 @@
 package io.janstenpickle.trace4cats
 
 import cats.kernel.Eq
-import io.janstenpickle.trace4cats.model.{SampleDecision, SpanContext, SpanId, TraceFlags, TraceHeaders, TraceId, TraceState}
+import io.janstenpickle.trace4cats.model.{
+  SampleDecision,
+  SpanContext,
+  SpanId,
+  TraceFlags,
+  TraceHeaders,
+  TraceId,
+  TraceState
+}
 import io.janstenpickle.trace4cats.test.ArbitraryInstances
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/W3cToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/W3cToHeadersSpec.scala
@@ -1,7 +1,7 @@
 package io.janstenpickle.trace4cats
 
 import cats.kernel.Eq
-import io.janstenpickle.trace4cats.model.{SampleDecision, SpanContext, SpanId, TraceFlags, TraceId, TraceState}
+import io.janstenpickle.trace4cats.model.{SampleDecision, SpanContext, SpanId, TraceFlags, TraceHeaders, TraceId, TraceState}
 import io.janstenpickle.trace4cats.test.ArbitraryInstances
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -19,7 +19,7 @@ class W3cToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks w
   }
 
   it should "decode an example traceparent header" in {
-    val headers = Map("traceparent" -> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    val headers = TraceHeaders.of("traceparent" -> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 
     val expected = for {
       traceId <- TraceId.fromHexString("4bf92f3577b34da6a3ce929d0e0e4736")
@@ -37,7 +37,7 @@ class W3cToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks w
   }
 
   it should "decode example traceparent and tracestate headers" in {
-    val headers = Map(
+    val headers = TraceHeaders.of(
       "traceparent" -> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
       "tracestate" -> "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE"
     )
@@ -63,13 +63,13 @@ class W3cToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks w
   }
 
   it should "not decode from empty headers" in {
-    assert(Eq[Option[SpanContext]].eqv(w3c.toContext(Map.empty), None))
+    assert(Eq[Option[SpanContext]].eqv(w3c.toContext(TraceHeaders.empty), None))
   }
 
   it should "not decode when only tracestate is available" in {
     assert(
       Eq[Option[SpanContext]]
-        .eqv(w3c.toContext(Map("tracestate" -> "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE")), None)
+        .eqv(w3c.toContext(TraceHeaders.of("tracestate" -> "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE")), None)
     )
   }
 }

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Fs2Example.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/Fs2Example.scala
@@ -16,7 +16,7 @@ import io.janstenpickle.trace4cats.fs2.syntax.all._
 import io.janstenpickle.trace4cats.inject.{EntryPoint, Trace}
 import io.janstenpickle.trace4cats.kernel.SpanSampler
 import io.janstenpickle.trace4cats.model.AttributeValue.LongValue
-import io.janstenpickle.trace4cats.model.{SpanKind, TraceProcess}
+import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders, TraceProcess}
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -84,12 +84,12 @@ object Fs2Example extends IOApp {
   // gets the trace headers from the span context so that they may be propagated across service boundaries
   def getHeaders[F[_]: Bracket[*[_], Throwable]](
     stream: TracedStream[F, Unit]
-  ): Stream[F, (Map[String, String], Unit)] =
+  ): Stream[F, (TraceHeaders, Unit)] =
     stream.traceHeaders.endTrace
 
   def continue[F[_]: Bracket[*[_], Throwable]](
     ep: EntryPoint[F],
-    stream: Stream[F, (Map[String, String], Unit)]
+    stream: Stream[F, (TraceHeaders, Unit)]
   ): TracedStream[F, Unit] =
     // inject the entry point and extract headers from the stream element
     stream

--- a/modules/fs2/src/test/scala/io/janstenpickle/trace4cats/fs2/syntax/Fs2StreamSyntaxSpec.scala
+++ b/modules/fs2/src/test/scala/io/janstenpickle/trace4cats/fs2/syntax/Fs2StreamSyntaxSpec.scala
@@ -8,7 +8,7 @@ import io.janstenpickle.trace4cats.{Span, ToHeaders}
 import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
 import io.janstenpickle.trace4cats.inject.{EntryPoint, Trace}
 import io.janstenpickle.trace4cats.kernel.SpanSampler
-import io.janstenpickle.trace4cats.model.{CompletedSpan, SampleDecision, SpanContext, TraceFlags}
+import io.janstenpickle.trace4cats.model.{CompletedSpan, SampleDecision, SpanContext, TraceFlags, TraceHeaders}
 import io.janstenpickle.trace4cats.test.ArbitraryInstances
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
@@ -194,7 +194,7 @@ class Fs2StreamSyntaxSpec
         completer <- RefSpanCompleter[IO](serviceName)
         ep = EntryPoint[IO](SpanSampler.always[IO], completer)
         _ <- Stream
-          .emit[IO, (String, Map[String, String])](rootName -> parentHeaders)
+          .emit[IO, (String, TraceHeaders)](rootName -> parentHeaders)
           .injectContinue(ep, _._1)(_._2)
           .evalMap(spanName)(_ => IO.unit)
           .endTrace
@@ -221,7 +221,7 @@ class Fs2StreamSyntaxSpec
         completer <- RefSpanCompleter[IO](serviceName)
         ep = EntryPoint[IO](SpanSampler.always[IO], completer)
         _ <- Stream
-          .emit[IO, (String, Map[String, String])](rootName -> parentHeaders)
+          .emit[IO, (String, TraceHeaders)](rootName -> parentHeaders)
           .injectContinue(ep, _._1)(_._2)
           .evalMap(spanName)(_ => IO.unit)
           .endTrace

--- a/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/ClientTracer.scala
+++ b/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/ClientTracer.scala
@@ -28,7 +28,7 @@ object ClientTracer {
             }
           ).flatMap { span =>
             val headers = toHeaders.fromContext(span.context)
-            val req = request.putHeaders(Http4sHeaders.traceHeadersToHttp(headers): _*)
+            val req = request.putHeaders(Http4sHeaders.converter.to(headers).toList: _*)
 
             client
               .run(req.mapK(provide.fk(span)))

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/BaseClientTracerSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/BaseClientTracerSpec.scala
@@ -4,10 +4,10 @@ import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
 import cats.effect.{Blocker, ConcurrentEffect, Sync, Timer}
 import cats.implicits._
-import cats.{Eq, Id, ~>}
+import cats.{~>, Eq, Id}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
-import io.janstenpickle.trace4cats.http4s.common.Http4sStatusMapping
+import io.janstenpickle.trace4cats.http4s.common.{Http4sHeaders, Http4sStatusMapping}
 import io.janstenpickle.trace4cats.inject.{EntryPoint, Provide, Trace}
 import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
 import io.janstenpickle.trace4cats.model.TraceHeaders
@@ -132,14 +132,7 @@ abstract class BaseClientTracerSpec[F[_]: ConcurrentEffect, G[_]: Sync: Trace](
         req
           .as[String]
           .flatMap { key =>
-            headersRef.update(
-              _.updated(
-                key,
-                TraceHeaders(req.headers.toList.map { header =>
-                  header.name.value -> header.value
-                }.toMap)
-              )
-            )
+            headersRef.update(_.updated(key, Http4sHeaders.converter.from(req.headers)))
           }
           .as(resp)
       }

--- a/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sHeaders.scala
+++ b/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sHeaders.scala
@@ -1,6 +1,6 @@
 package io.janstenpickle.trace4cats.http4s.common
 
-import io.janstenpickle.trace4cats.model.AttributeValue
+import io.janstenpickle.trace4cats.model.{AttributeValue, TraceHeaders}
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Header, Headers, Request, Response}
 
@@ -38,8 +38,8 @@ object Http4sHeaders {
       h.name.value -> h.value
     }.toMap
 
-  def traceHeadersToHttp(headers: Map[String, String]): List[Header] =
-    headers.toList.map { case (k, v) =>
+  def traceHeadersToHttp(headers: TraceHeaders): List[Header] =
+    headers.values.toList.map { case (k, v) =>
       Header(k, v)
     }
 }

--- a/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sHeaders.scala
+++ b/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sHeaders.scala
@@ -5,7 +5,7 @@ import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Header, Headers, Request, Response}
 
 object Http4sHeaders {
-  def headerMap(
+  def headerFields(
     headers: Headers,
     `type`: String,
     dropWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
@@ -18,7 +18,7 @@ object Http4sHeaders {
     req: Request[F],
     dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
   ): List[(String, AttributeValue)] =
-    List[(String, AttributeValue)]("http.method" -> req.method.name, "http.url" -> req.uri.path) ++ headerMap(
+    List[(String, AttributeValue)]("http.method" -> req.method.name, "http.url" -> req.uri.path) ++ headerFields(
       req.headers,
       "req",
       dropHeadersWhen
@@ -31,15 +31,12 @@ object Http4sHeaders {
     List[(String, AttributeValue)](
       "http.status_code" -> resp.status.code,
       "http.status_message" -> resp.status.reason
-    ) ++ headerMap(resp.headers, "resp", dropHeadersWhen)
+    ) ++ headerFields(resp.headers, "resp", dropHeadersWhen)
 
-  def reqHeaders[F[_]](req: Request[F]): Map[String, String] =
-    req.headers.toList.map { h =>
-      h.name.value -> h.value
-    }.toMap
-
-  def traceHeadersToHttp(headers: TraceHeaders): List[Header] =
-    headers.values.toList.map { case (k, v) =>
-      Header(k, v)
-    }
+  val converter: TraceHeaders.Converter[Headers] = new TraceHeaders.Converter[Headers] {
+    def from(t: Headers): TraceHeaders =
+      TraceHeaders(t.toList.map(h => h.name.value -> h.value).toMap)
+    def to(h: TraceHeaders): Headers =
+      Headers(h.values.map { case (k, v) => Header(k, v) }.toList)
+  }
 }

--- a/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sSpanNamer.scala
+++ b/modules/http4s-common/src/main/scala/io/janstenpickle/trace4cats/http4s/common/Http4sSpanNamer.scala
@@ -3,11 +3,11 @@ package io.janstenpickle.trace4cats.http4s.common
 import org.http4s.Uri
 
 object Http4sSpanNamer {
-  def method: Http4sSpanNamer = _.method.name
+  val method: Http4sSpanNamer = _.method.name
 
-  def path: Http4sSpanNamer = req => Uri.decode(req.pathInfo)
+  val path: Http4sSpanNamer = req => Uri.decode(req.pathInfo)
 
-  def methodWithPath: Http4sSpanNamer = req => s"${req.method.name} ${Uri.decode(req.pathInfo)}"
+  val methodWithPath: Http4sSpanNamer = req => s"${req.method.name} ${Uri.decode(req.pathInfo)}"
 
   /** Similar to `methodWithPath`, but allows one to reduce the cardinality of the operation name by applying
     * a transformation to each path segment, e.g.:

--- a/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/ServerTracer.scala
+++ b/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/ServerTracer.scala
@@ -14,7 +14,7 @@ import io.janstenpickle.trace4cats.http4s.common.{
   Http4sStatusMapping
 }
 import io.janstenpickle.trace4cats.inject.{EntryPoint, LiftTrace, Provide}
-import io.janstenpickle.trace4cats.model.SpanKind
+import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders}
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{HttpApp, HttpRoutes, Request, Response}
 
@@ -28,7 +28,7 @@ object ServerTracer {
   )(implicit provide: Provide[F, G], lift: LiftTrace[F, G]): HttpRoutes[F] =
     Kleisli[OptionT[F, *], Request[F], Response[F]] { req =>
       val filter = requestFilter.lift(req.covary).getOrElse(true)
-      val headers = req.headers.toList.map(h => h.name.value -> h.value).toMap
+      val headers = TraceHeaders(req.headers.toList.map(h => h.name.value -> h.value).toMap)
       val spanR =
         if (filter) entryPoint.continueOrElseRoot(spanNamer(req.covary), SpanKind.Server, headers) else Span.noop[F]
 
@@ -60,7 +60,7 @@ object ServerTracer {
   )(implicit provide: Provide[F, G], lift: LiftTrace[F, G]): HttpApp[F] =
     Kleisli[F, Request[F], Response[F]] { req =>
       val filter = requestFilter.lift(req.covary).getOrElse(true)
-      val headers = req.headers.toList.map(h => h.name.value -> h.value).toMap
+      val headers = TraceHeaders(req.headers.toList.map(h => h.name.value -> h.value).toMap)
       val spanR =
         if (filter) entryPoint.continueOrElseRoot(spanNamer(req.covary), SpanKind.Server, headers) else Span.noop[F]
 

--- a/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/KafkaHeaders.scala
+++ b/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/KafkaHeaders.scala
@@ -1,0 +1,14 @@
+package io.janstenpickle.trace4cats.kafka
+
+import cats.syntax.foldable._
+import fs2.kafka.{Header, Headers}
+import io.janstenpickle.trace4cats.model.TraceHeaders
+
+object KafkaHeaders {
+  val converter: TraceHeaders.Converter[Headers] = new TraceHeaders.Converter[Headers] {
+    def from(t: Headers): TraceHeaders =
+      t.toChain.foldMap(h => TraceHeaders.of(h.key() -> h.as[String]))
+    def to(h: TraceHeaders): Headers =
+      Headers.fromIterable(h.values.map { case (k, v) => Header(k, v) })
+  }
+}

--- a/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/TracedConsumer.scala
+++ b/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/TracedConsumer.scala
@@ -8,7 +8,7 @@ import fs2.kafka.{CommittableConsumerRecord, CommittableOffset}
 import io.janstenpickle.trace4cats.fs2.TracedStream
 import io.janstenpickle.trace4cats.fs2.syntax.Fs2StreamSyntax
 import io.janstenpickle.trace4cats.inject.{EntryPoint, LiftTrace, Provide, Trace}
-import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, TraceHeaders}
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind}
 
 object TracedConsumer extends Fs2StreamSyntax {
 
@@ -17,9 +17,7 @@ object TracedConsumer extends Fs2StreamSyntax {
   )(ep: EntryPoint[F])(implicit provide: Provide[F, G]): TracedStream[F, CommittableConsumerRecord[F, K, V]] =
     stream
       .injectContinue(ep, "kafka.receive", SpanKind.Consumer) { record =>
-        TraceHeaders(record.record.headers.toChain.foldLeft(Map.empty[String, String]) { (acc, header) =>
-          acc.updated(header.key(), header.as[String])
-        })
+        KafkaHeaders.converter.from(record.record.headers)
       }
       .evalMapTrace { record =>
         Trace[G]

--- a/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/TracedProducer.scala
+++ b/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/TracedProducer.scala
@@ -17,7 +17,7 @@ object TracedProducer {
       override def produce[P](records: ProducerRecords[K, V, P]): G[G[ProducerResult[K, V, P]]] =
         Trace[G].span("kafka.send", SpanKind.Producer) {
           Trace[G].headers(toHeaders).flatMap { traceHeaders =>
-            val msgHeaders = Headers.fromIterable(traceHeaders.values.map { case (k, v) => Header(k, v) })
+            val msgHeaders = KafkaHeaders.converter.to(traceHeaders)
 
             NonEmptyList
               .fromList(records.records.map(_.topic).toList)

--- a/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/TracedProducer.scala
+++ b/modules/kafka-client/src/main/scala/io/janstenpickle/trace4cats/kafka/TracedProducer.scala
@@ -17,7 +17,7 @@ object TracedProducer {
       override def produce[P](records: ProducerRecords[K, V, P]): G[G[ProducerResult[K, V, P]]] =
         Trace[G].span("kafka.send", SpanKind.Producer) {
           Trace[G].headers(toHeaders).flatMap { traceHeaders =>
-            val msgHeaders = Headers.fromIterable(traceHeaders.map { case (k, v) => Header(k, v) })
+            val msgHeaders = Headers.fromIterable(traceHeaders.values.map { case (k, v) => Header(k, v) })
 
             NonEmptyList
               .fromList(records.records.map(_.topic).toList)

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceHeaders.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceHeaders.scala
@@ -4,15 +4,21 @@ import cats.{Eq, Monoid, Show}
 import cats.syntax.contravariant._
 
 case class TraceHeaders(values: Map[String, String]) extends AnyVal {
-  def +(that: TraceHeaders): TraceHeaders = TraceHeaders(this.values ++ that.values)
+  def ++(that: TraceHeaders): TraceHeaders = TraceHeaders(this.values ++ that.values)
+  def +(elem: (String, String)): TraceHeaders = TraceHeaders(values + elem)
 }
 
 object TraceHeaders {
   def of(values: (String, String)*): TraceHeaders = TraceHeaders(values.toMap)
 
+  trait Converter[T] {
+    def from(t: T): TraceHeaders
+    def to(h: TraceHeaders): T
+  }
+
   val empty: TraceHeaders = TraceHeaders(Map.empty)
 
-  implicit val traceHeadersMonoid: Monoid[TraceHeaders] = Monoid.instance(empty, _ + _)
+  implicit val traceHeadersMonoid: Monoid[TraceHeaders] = Monoid.instance(empty, _ ++ _)
   implicit val traceHeadersShow: Show[TraceHeaders] = Show.catsShowForMap[String, String].contramap(_.values)
   implicit val traceHeadersEq: Eq[TraceHeaders] = Eq.catsKernelEqForMap[String, String].contramap(_.values)
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceHeaders.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceHeaders.scala
@@ -1,0 +1,18 @@
+package io.janstenpickle.trace4cats.model
+
+import cats.{Eq, Monoid, Show}
+import cats.syntax.contravariant._
+
+case class TraceHeaders(values: Map[String, String]) extends AnyVal {
+  def +(that: TraceHeaders): TraceHeaders = TraceHeaders(this.values ++ that.values)
+}
+
+object TraceHeaders {
+  def of(values: (String, String)*): TraceHeaders = TraceHeaders(values.toMap)
+
+  val empty: TraceHeaders = TraceHeaders(Map.empty)
+
+  implicit val traceHeadersMonoid: Monoid[TraceHeaders] = Monoid.instance(empty, _ + _)
+  implicit val traceHeadersShow: Show[TraceHeaders] = Show.catsShowForMap[String, String].contramap(_.values)
+  implicit val traceHeadersEq: Eq[TraceHeaders] = Eq.catsKernelEqForMap[String, String].contramap(_.values)
+}

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/KernelConverter.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/KernelConverter.scala
@@ -1,0 +1,9 @@
+package io.janstenpickle.trace4cats.natchez
+
+import io.janstenpickle.trace4cats.model.TraceHeaders
+import natchez.Kernel
+
+object KernelConverter extends TraceHeaders.Converter[Kernel] {
+  def from(t: Kernel): TraceHeaders = TraceHeaders(t.toHeaders)
+  def to(h: TraceHeaders): Kernel = Kernel(h.values)
+}

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsSpan.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsSpan.scala
@@ -19,7 +19,7 @@ final case class Trace4CatsSpan[F[_]: Sync: Clock](span: io.janstenpickle.trace4
       case (k, V.BooleanValue(v)) => k -> BooleanValue(v)
     }: _*)
 
-  override def kernel: F[Kernel] = Applicative[F].pure(Kernel(toHeaders.fromContext(span.context)))
+  override def kernel: F[Kernel] = Applicative[F].pure(Kernel(toHeaders.fromContext(span.context).values))
 
   override def span(name: String): Resource[F, Span[F]] =
     Trace4CatsSpan(span.child(name, SpanKind.Internal), toHeaders)

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsSpan.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsSpan.scala
@@ -19,7 +19,7 @@ final case class Trace4CatsSpan[F[_]: Sync: Clock](span: io.janstenpickle.trace4
       case (k, V.BooleanValue(v)) => k -> BooleanValue(v)
     }: _*)
 
-  override def kernel: F[Kernel] = Applicative[F].pure(Kernel(toHeaders.fromContext(span.context).values))
+  override def kernel: F[Kernel] = Applicative[F].pure(KernelConverter.to(toHeaders.fromContext(span.context)))
 
   override def span(name: String): Resource[F, Span[F]] =
     Trace4CatsSpan(span.child(name, SpanKind.Internal), toHeaders)

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsTracer.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsTracer.scala
@@ -3,7 +3,7 @@ package io.janstenpickle.trace4cats.natchez
 import cats.effect.{Clock, Resource, Sync}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
-import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders}
+import io.janstenpickle.trace4cats.model.SpanKind
 import natchez.{EntryPoint, Kernel, Span}
 
 object Trace4CatsTracer {
@@ -18,7 +18,7 @@ object Trace4CatsTracer {
 
       override def continue(name: String, kernel: Kernel): Resource[F, Span[F]] =
         Trace4CatsSpan(
-          toHeaders.toContext(TraceHeaders(kernel.toHeaders)) match {
+          toHeaders.toContext(KernelConverter.from(kernel)) match {
             case None => io.janstenpickle.trace4cats.Span.root(name, SpanKind.Server, sampler, completer)
             case Some(parent) =>
               io.janstenpickle.trace4cats.Span.child(name, parent, SpanKind.Server, sampler, completer)

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsTracer.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/Trace4CatsTracer.scala
@@ -3,7 +3,7 @@ package io.janstenpickle.trace4cats.natchez
 import cats.effect.{Clock, Resource, Sync}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
-import io.janstenpickle.trace4cats.model.SpanKind
+import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders}
 import natchez.{EntryPoint, Kernel, Span}
 
 object Trace4CatsTracer {
@@ -18,7 +18,7 @@ object Trace4CatsTracer {
 
       override def continue(name: String, kernel: Kernel): Resource[F, Span[F]] =
         Trace4CatsSpan(
-          toHeaders.toContext(kernel.toHeaders) match {
+          toHeaders.toContext(TraceHeaders(kernel.toHeaders)) match {
             case None => io.janstenpickle.trace4cats.Span.root(name, SpanKind.Server, sampler, completer)
             case Some(parent) =>
               io.janstenpickle.trace4cats.Span.child(name, parent, SpanKind.Server, sampler, completer)

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/Trace4CatsConversions.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/Trace4CatsConversions.scala
@@ -17,7 +17,7 @@ import io.janstenpickle.trace4cats.model.AttributeValue.{
   StringList,
   StringValue
 }
-import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, SpanStatus}
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, SpanStatus, TraceHeaders}
 
 trait Trace4CatsConversions {
   implicit def trace4CatsToNatchez[F[_]: Applicative](implicit trace: Trace[F]): NatchezTrace[F] =
@@ -28,7 +28,7 @@ trait Trace4CatsConversions {
           case (k, V.NumberValue(v)) => k -> DoubleValue(v.doubleValue())
           case (k, V.BooleanValue(v)) => k -> BooleanValue(v)
         }: _*)
-      override def kernel: F[Kernel] = trace.headers.map(Kernel)
+      override def kernel: F[Kernel] = trace.headers.map(h => Kernel(h.values))
       override def span[A](name: String)(k: F[A]): F[A] = trace.span[A](name)(k)
       override def traceId: F[Option[String]] = trace.traceId
       override def traceUri: F[Option[URI]] = Applicative[F].pure(None)
@@ -49,7 +49,7 @@ trait Trace4CatsConversions {
           case (k, LongList(v)) => k -> V.StringValue(v.toString())
         }: _*)
       override def span[A](name: String, kind: SpanKind)(fa: F[A]): F[A] = trace.span(name)(fa)
-      override def headers(toHeaders: ToHeaders): F[Map[String, String]] = trace.kernel.map(_.toHeaders)
+      override def headers(toHeaders: ToHeaders): F[TraceHeaders] = trace.kernel.map(k => TraceHeaders(k.toHeaders))
       override def setStatus(status: SpanStatus): F[Unit] = Applicative[F].unit
       override def traceId: F[Option[String]] = trace.traceId
     }

--- a/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/BackendTracer.scala
+++ b/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/BackendTracer.scala
@@ -32,8 +32,8 @@ class BackendTracer[F[_]: Bracket[*[_], Throwable], G[_]: MonadError[*[_], Throw
               }
             )
             .use { span =>
-              val headers = toHeaders.fromContext(span.context).values
-              val req = request.headers(headers)
+              val headers = SttpHeaders.converter.to(toHeaders.fromContext(span.context))
+              val req = request.headers(headers.headers: _*)
 
               backend.send(req).flatTap { resp =>
                 span.setStatus(SttpStatusMapping.statusToSpanStatus(resp.statusText, resp.code))

--- a/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/BackendTracer.scala
+++ b/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/BackendTracer.scala
@@ -32,7 +32,7 @@ class BackendTracer[F[_]: Bracket[*[_], Throwable], G[_]: MonadError[*[_], Throw
               }
             )
             .use { span =>
-              val headers = toHeaders.fromContext(span.context)
+              val headers = toHeaders.fromContext(span.context).values
               val req = request.headers(headers)
 
               backend.send(req).flatTap { resp =>

--- a/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/SttpHeaders.scala
+++ b/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/SttpHeaders.scala
@@ -1,0 +1,13 @@
+package io.janstenpickle.trace4cats.sttp.backend
+
+import io.janstenpickle.trace4cats.model.TraceHeaders
+import sttp.model.{Header, Headers}
+
+object SttpHeaders {
+  val converter: TraceHeaders.Converter[Headers] = new TraceHeaders.Converter[Headers] {
+    def from(t: Headers): TraceHeaders =
+      TraceHeaders(t.headers.map(h => h.value -> h.name).toMap)
+    def to(h: TraceHeaders): Headers =
+      Headers(h.values.map { case (k, v) => Header(k, v) }.toList)
+  }
+}

--- a/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/SttpSpanNamer.scala
+++ b/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/backend/SttpSpanNamer.scala
@@ -1,11 +1,11 @@
 package io.janstenpickle.trace4cats.sttp.backend
 
 object SttpSpanNamer {
-  def method: SttpSpanNamer = _.method.method
+  val method: SttpSpanNamer = _.method.method
 
-  def path: SttpSpanNamer = req => req.uri.path.mkString("/")
+  val path: SttpSpanNamer = req => req.uri.path.mkString("/")
 
-  def methodWithPath: SttpSpanNamer = req => s"${req.method.method} ${req.uri.path.mkString("/")}"
+  val methodWithPath: SttpSpanNamer = req => s"${req.method.method} ${req.uri.path.mkString("/")}"
 
   /** Similar to `methodWithPath`, but allows one to reduce the cardinality of the operation name by applying
     * a transformation to each path segment, e.g.:

--- a/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/backend/BaseBackendTracerSpec.scala
+++ b/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/backend/BaseBackendTracerSpec.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
 import cats.effect.{Blocker, ConcurrentEffect, ContextShift, Sync, Timer}
 import cats.implicits._
-import cats.{Eq, Id, ~>}
+import cats.{~>, Eq, Id}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
 import io.janstenpickle.trace4cats.http4s.common.Http4sHeaders

--- a/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/backend/BaseBackendTracerSpec.scala
+++ b/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/backend/BaseBackendTracerSpec.scala
@@ -4,9 +4,10 @@ import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
 import cats.effect.{Blocker, ConcurrentEffect, ContextShift, Sync, Timer}
 import cats.implicits._
-import cats.{~>, Eq, Id}
+import cats.{Eq, Id, ~>}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
+import io.janstenpickle.trace4cats.http4s.common.Http4sHeaders
 import io.janstenpickle.trace4cats.inject.{EntryPoint, Provide, Trace}
 import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
 import io.janstenpickle.trace4cats.model.TraceHeaders
@@ -128,14 +129,7 @@ abstract class BaseBackendTracerSpec[F[_]: ConcurrentEffect: ContextShift, G[_]:
         req
           .as[String]
           .flatMap { key =>
-            headersRef.update(
-              _.updated(
-                key,
-                TraceHeaders(req.headers.toList.map { header =>
-                  header.name.value -> header.value
-                }.toMap)
-              )
-            )
+            headersRef.update(_.updated(key, Http4sHeaders.converter.from(req.headers)))
           }
           .as(resp)
       }


### PR DESCRIPTION
Closes #124 

Along with `TraceHeaders` type itself, I also added converters to/from integrations to remove in-place conversions.

@janstenpickle need your review on naming