### PR TITLE
Add aliases for global scalafmt formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -733,3 +733,6 @@ lazy val `collector-lite` = (project in file("modules/collector-lite"))
     `graal-kafka`
   )
   .enablePlugins(GraalVMNativeImagePlugin)
+
+addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
+addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")


### PR DESCRIPTION
I hate when my PRs fail due to `scalafmtCheck`. 

Add `sbt` aliases that globally check and format the whole codebase with scalafmt:
* `fmt` formats all sources in all modules
* `fmtCheck` checks the same