### PR TITLE
Set span attributes from request

### DIFF
--- a/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/Http4sResourceKleislis.scala
+++ b/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/Http4sResourceKleislis.scala
@@ -7,25 +7,30 @@ import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.http4s.common.{Http4sHeaders, Http4sRequestFilter, Http4sSpanNamer, Request_}
 import io.janstenpickle.trace4cats.inject.{ResourceKleisli, SpanParams}
 import io.janstenpickle.trace4cats.model.SpanKind
+import org.http4s.Headers
+import org.http4s.util.CaseInsensitiveString
 
 object Http4sResourceKleislis {
   def fromHeadersContext[F[_]: Monad, Ctx](
     makeContext: (Request_, Span[F]) => F[Ctx],
     spanNamer: Http4sSpanNamer = Http4sSpanNamer.methodWithPath,
-    requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll
+    requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
+    dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
   )(k: ResourceKleisli[F, SpanParams, Span[F]]): ResourceKleisli[F, Request_, Ctx] =
-    fromHeaders[F](spanNamer, requestFilter)(k).tapWithF { (req, span) =>
+    fromHeaders[F](spanNamer, requestFilter, dropHeadersWhen)(k).tapWithF { (req, span) =>
       Resource.liftF(makeContext(req, span))
     }
 
   def fromHeaders[F[_]: Applicative](
     spanNamer: Http4sSpanNamer = Http4sSpanNamer.methodWithPath,
     requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
+    dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
   )(k: ResourceKleisli[F, SpanParams, Span[F]]): ResourceKleisli[F, Request_, Span[F]] =
     Kleisli { req =>
       val filter = requestFilter.lift(req).getOrElse(true)
-      val headers = Http4sHeaders.converter.from(req.headers)
+      lazy val headers = Http4sHeaders.converter.from(req.headers)
+      val spanResource = if (filter) k.run((spanNamer(req), SpanKind.Server, headers)) else Span.noop[F]
 
-      if (filter) k.run((spanNamer(req), SpanKind.Server, headers)) else Span.noop[F]
+      spanResource.evalTap(_.putAll(Http4sHeaders.requestFields(req, dropHeadersWhen): _*))
     }
 }

--- a/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntax.scala
+++ b/modules/http4s-server/src/main/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntax.scala
@@ -36,7 +36,9 @@ trait ServerSyntax {
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     )(implicit P: Provide[F, G, Ctx], F: BracketThrow[F], G: Monad[G], trace: Trace[G]): HttpRoutes[F] = {
       val context =
-        Http4sResourceKleislis.fromHeadersContext(makeContext, spanNamer, requestFilter)(entryPoint.toKleisli)
+        Http4sResourceKleislis.fromHeadersContext(makeContext, spanNamer, requestFilter, dropHeadersWhen)(
+          entryPoint.toKleisli
+        )
 
       ServerTracer.injectRoutes(routes, context, dropHeadersWhen)
     }
@@ -56,7 +58,7 @@ trait ServerSyntax {
       requestFilter: Http4sRequestFilter = Http4sRequestFilter.allowAll,
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     )(implicit P: Provide[F, G, Span[F]], F: BracketThrow[F], G: Monad[G], trace: Trace[G]): HttpApp[F] = {
-      val context = Http4sResourceKleislis.fromHeaders(spanNamer, requestFilter)(entryPoint.toKleisli)
+      val context = Http4sResourceKleislis.fromHeaders(spanNamer, requestFilter, dropHeadersWhen)(entryPoint.toKleisli)
 
       ServerTracer.injectApp(app, context, dropHeadersWhen)
     }
@@ -75,7 +77,9 @@ trait ServerSyntax {
       dropHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
     )(implicit P: Provide[F, G, Ctx], F: BracketThrow[F], G: Monad[G], trace: Trace[G]): HttpApp[F] = {
       val context =
-        Http4sResourceKleislis.fromHeadersContext(makeContext, spanNamer, requestFilter)(entryPoint.toKleisli)
+        Http4sResourceKleislis.fromHeadersContext(makeContext, spanNamer, requestFilter, dropHeadersWhen)(
+          entryPoint.toKleisli
+        )
 
       ServerTracer.injectApp(app, context, dropHeadersWhen)
     }


### PR DESCRIPTION
Creation of a custom context can be side effecting. The introduction
of the resource Kleisli and subsequent changes meant that if the
creation of a custom context failed, http4s request headers would
not be set. This ensures that the default Kleisli implementation
of `Request => Span` sets span attributes before creating the
custom context.

The http4s tracer still sets the request headers as attributes, in
case someone wants to provide their own `ResourceKleisli` without
setting the request header attributes.

@catostrophe this should resolve the issue you mentioned in #129 