### PR TITLE
Remove http4s server dependency in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -546,12 +546,7 @@ lazy val `sttp-client` = (project in file("modules/sttp-client"))
   .settings(
     name := "trace4cats-sttp-client",
     libraryDependencies ++= Seq(Dependencies.sttpClient),
-    libraryDependencies ++= (Dependencies.test ++ Seq(
-      Dependencies.http4sBlazeClient,
-      Dependencies.http4sBlazeServer,
-      Dependencies.http4sDsl,
-      Dependencies.sttpHttp4s
-    )).map(_ % Test)
+    libraryDependencies ++= (Dependencies.test ++ Seq(Dependencies.http4sDsl, Dependencies.sttpHttp4s)).map(_ % Test)
   )
   .dependsOn(
     model,
@@ -568,11 +563,7 @@ lazy val `http4s-client` = (project in file("modules/http4s-client"))
   .settings(
     name := "trace4cats-http4s-client",
     libraryDependencies ++= Seq(Dependencies.http4sClient),
-    libraryDependencies ++= (Dependencies.test ++ Seq(
-      Dependencies.http4sBlazeClient,
-      Dependencies.http4sBlazeServer,
-      Dependencies.http4sDsl
-    )).map(_ % Test)
+    libraryDependencies ++= (Dependencies.test ++ Seq(Dependencies.http4sDsl)).map(_ % Test)
   )
   .dependsOn(
     model,
@@ -588,8 +579,7 @@ lazy val `http4s-server` = (project in file("modules/http4s-server"))
   .settings(
     name := "trace4cats-http4s-server",
     libraryDependencies ++= Seq(Dependencies.http4sServer),
-    libraryDependencies ++= (Dependencies.test ++ Seq(Dependencies.http4sBlazeClient, Dependencies.http4sBlazeServer))
-      .map(_ % Test)
+    libraryDependencies ++= (Dependencies.test ++ Seq(Dependencies.http4sClient)).map(_ % Test)
   )
   .dependsOn(
     model,

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientCtxSyntaxSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientCtxSyntaxSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.ExecutionContext
 
 class ClientCtxSyntaxSpec
     extends BaseClientTracerSpec[IO, Kleisli[IO, TraceContext[IO], *], TraceContext[IO]](
-      9085,
       λ[IO ~> Id](_.unsafeRunSync()),
       TraceContext("3d86cad5-d321-448f-a758-d28714fc1045", _),
       _.liftTraceContext(spanLens = TraceContext.span[IO], headersGetter = TraceContext.headers[IO](ToHeaders.all)),

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientSyntaxSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientSyntaxSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContext
 
 class ClientSyntaxSpec
     extends BaseClientTracerSpec[IO, Kleisli[IO, Span[IO], *], Span[IO]](
-      9084,
       λ[IO ~> Id](_.unsafeRunSync()),
       identity,
       _.liftTrace(),

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerCtxSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerCtxSyntaxSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContext
 
 class ResourceKleisliServerCtxSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, TraceContext[IO], *]](
-      9183,
       λ[IO ~> Id](_.unsafeRunSync()),
       λ[Kleisli[IO, TraceContext[IO], *] ~> IO](ga => TraceContext.empty[IO].flatMap(ga.run)),
       (routes, filter, ep) =>

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerSyntaxSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContext
 
 class ResourceKleisliServerSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, Span[IO], *]](
-      9182,
       λ[IO ~> Id](_.unsafeRunSync()),
       λ[Kleisli[IO, Span[IO], *] ~> IO](ga => Span.noop[IO].use(ga.run)),
       (routes, filter, ep) => routes.traced(Http4sResourceKleislis.fromHeaders(requestFilter = filter)(ep.toKleisli)),

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerCtxSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerCtxSyntaxSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContext
 
 class ServerCtxSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, TraceContext[IO], *]](
-      9083,
       λ[IO ~> Id](_.unsafeRunSync()),
       λ[Kleisli[IO, TraceContext[IO], *] ~> IO](ga => TraceContext.empty[IO].flatMap(ga.run)),
       (routes, filter, ep) => routes.injectContext(ep, makeContext = TraceContext.make[IO], requestFilter = filter),

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContext
 
 class ServerSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, Span[IO], *]](
-      9082,
       λ[IO ~> Id](_.unsafeRunSync()),
       λ[Kleisli[IO, Span[IO], *] ~> IO](ga => Span.noop[IO].use(ga.run)),
       (routes, filter, ep) => routes.inject(ep, requestFilter = filter),

--- a/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/client/BaseBackendTracerSpec.scala
+++ b/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/client/BaseBackendTracerSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.concurrent.Ref
 import cats.effect.{Blocker, ConcurrentEffect, ContextShift, Sync, Timer}
 import cats.implicits._
 import cats.{~>, Eq, Id}
-import io.janstenpickle.trace4cats.{Span, ToHeaders}
 import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
 import io.janstenpickle.trace4cats.base.context.Provide
 import io.janstenpickle.trace4cats.http4s.common.Http4sHeaders
@@ -13,11 +12,11 @@ import io.janstenpickle.trace4cats.inject.{EntryPoint, Trace}
 import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
 import io.janstenpickle.trace4cats.model.TraceHeaders
 import io.janstenpickle.trace4cats.sttp.client.syntax.{INothing, INothingT}
-import org.http4s.client.blaze.BlazeClientBuilder
+import io.janstenpickle.trace4cats.{Span, ToHeaders}
+import org.http4s.client.Client
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.`WWW-Authenticate`
 import org.http4s.implicits.http4sKleisliResponseSyntaxOptionT
-import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.{Challenge, HttpApp, HttpRoutes, Response}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertion
@@ -28,10 +27,7 @@ import sttp.client._
 import sttp.client.http4s.Http4sBackend
 import sttp.model.StatusCode
 
-import scala.concurrent.duration._
-
 abstract class BaseBackendTracerSpec[F[_]: ConcurrentEffect: ContextShift, G[_]: Sync: Trace, Ctx](
-  port: Int,
   unsafeRunK: F ~> Id,
   makeSomeContext: Span[F] => Ctx,
   liftBackend: SttpBackend[F, INothing, INothingT] => SttpBackend[G, INothing, INothingT],
@@ -72,53 +68,50 @@ abstract class BaseBackendTracerSpec[F[_]: ConcurrentEffect: ContextShift, G[_]:
 
       val (httpApp, headersRef) = makeHttpApp(response)
 
-      unsafeRunK(withRunningHttpServer(httpApp) { port =>
-        RefSpanCompleter[F]("test").flatMap { completer =>
-          withBackend { backend =>
-            def req(body: String): G[Unit] =
-              runReq(backend, basicRequest.get(uri"http://localhost:$port").body(body))
+      unsafeRunK(RefSpanCompleter[F]("test").flatMap { completer =>
+        withBackend(httpApp) { backend =>
+          def req(body: String): G[Unit] =
+            runReq(backend, basicRequest.get(uri"http:///").body(body))
 
-            for {
-              _ <- entryPoint(completer)
-                .root(rootSpanName)
-                .use { span =>
-                  P.provideK(makeSomeContext(span))(
-                    Trace[G]
-                      .span(req1SpanName)(req(req1SpanName))
-                      .handleError(_ => ()) >> Trace[G].span(req2SpanName)(req(req2SpanName)).handleError(_ => ())
-                  )
-                }
-              spans <- completer.get
-              headersMap <- headersRef.get
-            } yield {
-              (spans.toList.map(_.name) should contain)
-                .theSameElementsAs(List("GET ", "GET ", rootSpanName, req1SpanName, req2SpanName))
-              (headersMap.keys should contain).theSameElementsAs(Set(req1SpanName, req2SpanName))
-
-              assert(
-                Eq.eqv(
-                  ToHeaders.w3c.toContext(headersMap(req1SpanName)).get.spanId,
-                  spans.toList.sortBy(_.`end`.toEpochMilli).find(_.name == "GET ").get.context.spanId
+          for {
+            _ <- entryPoint(completer)
+              .root(rootSpanName)
+              .use { span =>
+                P.provideK(makeSomeContext(span))(
+                  Trace[G]
+                    .span(req1SpanName)(req(req1SpanName))
+                    .handleError(_ => ()) >> Trace[G].span(req2SpanName)(req(req2SpanName)).handleError(_ => ())
                 )
+              }
+            spans <- completer.get
+            headersMap <- headersRef.get
+          } yield {
+            (spans.toList.map(_.name) should contain)
+              .theSameElementsAs(List("GET ", "GET ", rootSpanName, req1SpanName, req2SpanName))
+            (headersMap.keys should contain).theSameElementsAs(Set(req1SpanName, req2SpanName))
+
+            assert(
+              Eq.eqv(
+                ToHeaders.w3c.toContext(headersMap(req1SpanName)).get.spanId,
+                spans.toList.sortBy(_.`end`.toEpochMilli).find(_.name == "GET ").get.context.spanId
               )
+            )
 
-              assert(
-                Eq.eqv(
-                  ToHeaders.w3c.toContext(headersMap(req2SpanName)).get.spanId,
-                  spans.toList.sortBy(_.`end`.toEpochMilli).reverse.find(_.name == "GET ").get.context.spanId
-                )
+            assert(
+              Eq.eqv(
+                ToHeaders.w3c.toContext(headersMap(req2SpanName)).get.spanId,
+                spans.toList.sortBy(_.`end`.toEpochMilli).reverse.find(_.name == "GET ").get.context.spanId
               )
+            )
 
-              val expectedStatus =
-                SttpStatusMapping.statusToSpanStatus(response.status.reason, StatusCode(response.status.code))
-              (spans.toList.collect {
-                case span if span.name == "GET " => span.status
-              } should contain).theSameElementsAs(List.fill(2)(expectedStatus))
+            val expectedStatus =
+              SttpStatusMapping.statusToSpanStatus(response.status.reason, StatusCode(response.status.code))
+            (spans.toList.collect {
+              case span if span.name == "GET " => span.status
+            } should contain).theSameElementsAs(List.fill(2)(expectedStatus))
 
-            }
           }
         }
-
       })
     }
 
@@ -139,26 +132,7 @@ abstract class BaseBackendTracerSpec[F[_]: ConcurrentEffect: ContextShift, G[_]:
       .orNotFound -> headersRef
   }
 
-  def withBackend(fa: SttpBackend[G, Nothing, NothingT] => F[Assertion]): F[Assertion] =
-    Blocker[F]
-      .use { blocker =>
-        BlazeClientBuilder[F](blocker.blockingContext).resource.use { client =>
-          fa(liftBackend(Http4sBackend.usingClient(client, blocker)))
-        }
-      }
-
-  def withRunningHttpServer(app: HttpApp[F])(fa: Int => F[Assertion]): F[Assertion] = {
-    Blocker[F]
-      .flatMap { blocker =>
-        BlazeServerBuilder[F](blocker.blockingContext)
-          .bindHttp(port, "localhost")
-          .withHttpApp(app)
-          .resource
-
-      }
-      .use { _ =>
-        fa(port).flatTap(_ => timer.sleep(100.millis))
-      }
-  }
+  def withBackend(app: HttpApp[F])(fa: SttpBackend[G, Nothing, NothingT] => F[Assertion]): F[Assertion] =
+    Blocker[F].use(blocker => fa(liftBackend(Http4sBackend.usingClient(Client.fromHttpApp(app), blocker))))
 
 }

--- a/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/client/TracedBackendCtxSpec.scala
+++ b/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/client/TracedBackendCtxSpec.scala
@@ -12,7 +12,6 @@ import scala.concurrent.ExecutionContext
 
 class TracedBackendCtxSpec
     extends BaseBackendTracerSpec[IO, Kleisli[IO, TraceContext[IO], *], TraceContext[IO]](
-      9094,
       λ[IO ~> Id](_.unsafeRunSync()),
       TraceContext("bf2665b3-2201-466d-868d-8bd3ab151d79", _),
       _.liftTraceContext(spanLens = TraceContext.span[IO], headersGetter = TraceContext.headers[IO](ToHeaders.all)),

--- a/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/client/TracedBackendSpec.scala
+++ b/modules/sttp-client/src/test/scala/io/janstenpickle/trace4cats/sttp/client/TracedBackendSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.ExecutionContext
 
 class TracedBackendSpec
     extends BaseBackendTracerSpec[IO, Kleisli[IO, Span[IO], *], Span[IO]](
-      9093,
       λ[IO ~> Id](_.unsafeRunSync()),
       identity,
       _.liftTrace(),


### PR DESCRIPTION
No need to bind to ports when algebra can just be used

Fixes #178 