### PR TITLE
Update .mergify.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "janstenpickle"
+      - "catostrophe"
+    labels:
+      - "dependency-update"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,21 +1,66 @@
 pull_request_rules:
-  - name: automatically merge scala-steward's PRs
+  - name: delete head branch after merge
+    conditions: []
+    actions:
+      delete_head_branch: {}
+
+  - name: request reviews and label scala-steward's PRs
+    conditions:
+      - author=scala-steward
+    actions:
+      request_reviews:
+        users: [janstenpickle, catostrophe]
+      label:
+        add: [dependency-update]
+
+  - name: automatically merge scala-steward's PRs affecting project plugins
+    conditions:
+      - author=scala-steward
+      - status-success~=test \(2.12
+      - status-success~=test \(2.13
+      - "#files=1"
+      - files=project/plugins.sbt
+    actions:
+      merge:
+        method: merge
+
+  - name: automatically merge scala-steward's PRs affecting project build properties
+    conditions:
+      - author=scala-steward
+      - status-success~=test \(2.12
+      - status-success~=test \(2.13
+      - "#files=1"
+      - files=project/build.properties
+    actions:
+      merge:
+        method: merge
+
+  - name: automatically merge scala-steward's PRs updating semver-patch versions
     conditions:
       - author=scala-steward
       - status-success~=test \(2.12
       - status-success~=test \(2.13
       - body~=labels:.*semver-patch
     actions:
-      label:
-        add: [dependencies]
       merge:
         method: merge
- 
-  - name: automatically merge dependabot's PRs
+
+  - name: automatically merge other scala-steward's PRs reviewed by 1 maintainer
+    conditions:
+      - author=scala-steward
+      - status-success~=test \(2.12
+      - status-success~=test \(2.13
+      - "#approved-reviews-by>=1"
+    actions:
+      merge:
+        method: merge
+
+  - name: automatically merge dependabot's PRs reviewed by 1 maintainer
     conditions:
       - author=dependabot[bot]
       - status-success~=test \(2.12
       - status-success~=test \(2.13
+      - "#approved-reviews-by>=1"
     actions:
       merge:
         method: merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,5 +6,16 @@ pull_request_rules:
       - status-success~=test \(2.13
       - body~=labels:.*semver-patch
     actions:
+      label:
+        add: [dependencies]
+      merge:
+        method: merge
+ 
+  - name: automatically merge dependabot's PRs
+    conditions:
+      - author=dependabot[bot]
+      - status-success~=test \(2.12
+      - status-success~=test \(2.13
+    actions:
       merge:
         method: merge


### PR DESCRIPTION
Automatically merge dependabot's PRs.

Add `dependencies` label for Steward's PRs - it may be useful to mark all dependency updates with this label.