### PR TITLE
Remove dependabot PRs from Mergify config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        uses: crazy-max/ghaction-import-gpg@v2
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PGP_PASS }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -54,13 +54,3 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-
-  - name: automatically merge dependabot's PRs reviewed by 1 maintainer
-    conditions:
-      - author=dependabot[bot]
-      - status-success~=test \(2.12
-      - status-success~=test \(2.13
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: merge


### PR DESCRIPTION
Mergify is not allowed to merge PRs into `.github/workflows`.

Moreover, some steps aren't checked on branch build.