### PR TITLE
Fix diverging implicits in Natchez conversions

### DIFF
--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/InjectExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/InjectExample.scala
@@ -21,7 +21,7 @@ import io.janstenpickle.trace4cats.avro.AvroSpanCompleter
 import io.janstenpickle.trace4cats.inject.{EntryPoint, Trace}
 import io.janstenpickle.trace4cats.kernel.SpanSampler
 import io.janstenpickle.trace4cats.model.TraceProcess
-import io.janstenpickle.trace4cats.natchez.conversions._
+import io.janstenpickle.trace4cats.natchez.conversions.toNatchez._
 import natchez.{Trace => NatchezTrace}
 
 import scala.concurrent.duration._

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/InjectZioExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/InjectZioExample.scala
@@ -21,7 +21,7 @@ import io.janstenpickle.trace4cats.inject.zio._
 import io.janstenpickle.trace4cats.inject.{EntryPoint, Trace}
 import io.janstenpickle.trace4cats.kernel.SpanSampler
 import io.janstenpickle.trace4cats.model.TraceProcess
-import io.janstenpickle.trace4cats.natchez.conversions._
+import io.janstenpickle.trace4cats.natchez.conversions.toNatchez._
 import natchez.{Trace => NatchezTrace}
 import zio.interop.catz._
 import zio.interop.catz.implicits._

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/NatchezExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/NatchezExample.scala
@@ -21,7 +21,7 @@ import io.janstenpickle.trace4cats.inject.{Trace => T4CTrace}
 import io.janstenpickle.trace4cats.kernel.SpanSampler
 import io.janstenpickle.trace4cats.model.TraceProcess
 import io.janstenpickle.trace4cats.natchez.Trace4CatsTracer
-import io.janstenpickle.trace4cats.natchez.conversions._
+import io.janstenpickle.trace4cats.natchez.conversions.fromNatchez._
 import natchez.{EntryPoint, Trace, Span => NatchezSpan}
 
 import scala.concurrent.duration._

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/Trace4CatsToNatchez.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/Trace4CatsToNatchez.scala
@@ -1,0 +1,26 @@
+package io.janstenpickle.trace4cats.natchez.conversions
+
+import java.net.URI
+
+import _root_.natchez.{Kernel, Trace => NatchezTrace, TraceValue => V}
+import cats.Applicative
+import cats.syntax.functor._
+import io.janstenpickle.trace4cats.inject.Trace
+import io.janstenpickle.trace4cats.model.AttributeValue.{BooleanValue, DoubleValue, StringValue}
+import io.janstenpickle.trace4cats.natchez.KernelConverter
+
+trait Trace4CatsToNatchez {
+  implicit def trace4CatsToNatchez[F[_]: Applicative](implicit trace: Trace[F]): NatchezTrace[F] =
+    new NatchezTrace[F] {
+      override def put(fields: (String, V)*): F[Unit] =
+        trace.putAll(fields.map {
+          case (k, V.StringValue(v)) => k -> StringValue(v)
+          case (k, V.NumberValue(v)) => k -> DoubleValue(v.doubleValue())
+          case (k, V.BooleanValue(v)) => k -> BooleanValue(v)
+        }: _*)
+      override def kernel: F[Kernel] = trace.headers.map(KernelConverter.to)
+      override def span[A](name: String)(k: F[A]): F[A] = trace.span[A](name)(k)
+      override def traceId: F[Option[String]] = trace.traceId
+      override def traceUri: F[Option[URI]] = Applicative[F].pure(None)
+    }
+}

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/fromNatchez.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/fromNatchez.scala
@@ -1,0 +1,3 @@
+package io.janstenpickle.trace4cats.natchez.conversions
+
+object fromNatchez extends NatchezToTrace4Cats

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/package.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/package.scala
@@ -1,3 +1,0 @@
-package io.janstenpickle.trace4cats.natchez
-
-package object conversions extends Trace4CatsConversions

--- a/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/toNatchez.scala
+++ b/modules/natchez/src/main/scala/io/janstenpickle/trace4cats/natchez/conversions/toNatchez.scala
@@ -1,0 +1,3 @@
+package io.janstenpickle.trace4cats.natchez.conversions
+
+object toNatchez extends Trace4CatsToNatchez


### PR DESCRIPTION
Having conversions to both directions causes divergence in implicit search. They are usually never needed together.
At least they can be locally imported now.