### PR TITLE
Invert control for RNG for IDs

### DIFF
--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanId.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanId.scala
@@ -1,8 +1,9 @@
 package io.janstenpickle.trace4cats.model
 
-import java.util.concurrent.ThreadLocalRandom
+import cats.syntax.functor._
 import cats.syntax.show._
-import cats.{ApplicativeError, Defer, Eq, Show}
+import cats.{Eq, Functor, Show}
+import io.janstenpickle.trace4cats.model.random.Random
 import org.apache.commons.codec.binary.Hex
 
 import scala.util.Try
@@ -12,12 +13,7 @@ case class SpanId private (value: Array[Byte]) extends AnyVal {
 }
 
 object SpanId {
-  def apply[F[_]: Defer: ApplicativeError[*[_], Throwable]]: F[SpanId] =
-    Defer[F].defer(ApplicativeError[F, Throwable].catchNonFatal {
-      val array: Array[Byte] = Array.fill(8)(0)
-      ThreadLocalRandom.current.nextBytes(array)
-      new SpanId(array)
-    })
+  def apply[F[_]: Functor: Random]: F[SpanId] = Random[F].nextBytes(8).map(new SpanId(_))
 
   def fromHexString(hex: String): Option[SpanId] =
     Try(Hex.decodeHex(hex)).toOption.flatMap(apply)

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceId.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceId.scala
@@ -1,8 +1,9 @@
 package io.janstenpickle.trace4cats.model
 
-import java.util.concurrent.ThreadLocalRandom
+import cats.syntax.functor._
 import cats.syntax.show._
-import cats.{ApplicativeError, Defer, Eq, Show}
+import cats.{Eq, Functor, Show}
+import io.janstenpickle.trace4cats.model.random.Random
 import org.apache.commons.codec.binary.Hex
 
 import scala.util.Try
@@ -12,12 +13,7 @@ case class TraceId private (value: Array[Byte]) extends AnyVal {
 }
 
 object TraceId {
-  def apply[F[_]: Defer: ApplicativeError[*[_], Throwable]]: F[TraceId] =
-    Defer[F].defer(ApplicativeError[F, Throwable].catchNonFatal {
-      val array: Array[Byte] = Array.fill(16)(0)
-      ThreadLocalRandom.current.nextBytes(array)
-      new TraceId(array)
-    })
+  def apply[F[_]: Functor: Random]: F[TraceId] = Random[F].nextBytes(16).map(new TraceId(_))
 
   def fromHexString(hex: String): Option[TraceId] =
     Try(Hex.decodeHex(hex)).toOption.flatMap(apply)

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/random/Random.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/random/Random.scala
@@ -1,0 +1,22 @@
+package io.janstenpickle.trace4cats.model.random
+
+import cats.{ApplicativeError, Defer}
+
+import java.util.concurrent.ThreadLocalRandom
+
+// TODO: CE3 replace with built-in cats.effect.std.Random
+trait Random[F[_]] {
+  def nextBytes(n: Int): F[Array[Byte]]
+}
+
+object Random {
+  def apply[F[_]](implicit random: Random[F]): Random[F] = random
+
+  implicit def threadLocal[F[_]: Defer: ApplicativeError[*[_], Throwable]]: Random[F] = new Random[F] {
+    override def nextBytes(n: Int): F[Array[Byte]] = Defer[F].defer(ApplicativeError[F, Throwable].catchNonFatal {
+      val array: Array[Byte] = Array.fill(n)(0)
+      ThreadLocalRandom.current.nextBytes(array)
+      array
+    })
+  }
+}


### PR DESCRIPTION
Closes #346

Adds a new (temporary) typeclass for generating random bytes,
to be replaced with `cats.effect.std.Random` when upgrading to
CE3