### PR TITLE
Fix fluky Jaeger tests

### DIFF
--- a/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanCompleterSpec.scala
+++ b/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanCompleterSpec.scala
@@ -11,7 +11,11 @@ import scala.concurrent.duration._
 
 class JaegerSpanCompleterSpec extends BaseJaegerSpec {
   it should "Send a span to jaeger" in forAll { (span: CompletedSpan.Builder, process: TraceProcess) =>
-    val updatedSpan = span.copy(start = Instant.now(), end = Instant.now())
+    val updatedSpan = span.copy(
+      start = Instant.now(),
+      end = Instant.now(),
+      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+    )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 
     testCompleter(

--- a/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporterSpec.scala
+++ b/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporterSpec.scala
@@ -15,7 +15,7 @@ class JaegerSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = process.attributes ++ span.attributes,
+            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) => key == "ip" },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleterSpec.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleterSpec.scala
@@ -13,7 +13,11 @@ class OpenTelemetryJaegerSpanCompleterSpec extends BaseJaegerSpec {
   it should "Send a span to jaeger" in forAll { (span: CompletedSpan.Builder, serviceName: String) =>
     val process = TraceProcess(serviceName)
 
-    val updatedSpan = span.copy(start = Instant.now(), end = Instant.now(), links = span.links)
+    val updatedSpan = span.copy(
+      start = Instant.now(),
+      end = Instant.now(),
+      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+    )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 
     testCompleter(

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporterSpec.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporterSpec.scala
@@ -14,8 +14,7 @@ class OpenTelemetryJaegerSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = process.attributes ++ span.allAttributes,
-            links = span.links,
+            attributes = (process.attributes ++ span.allAttributes).filterNot { case (key, _) => key == "ip" },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleterSpec.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleterSpec.scala
@@ -13,7 +13,11 @@ class OpenTelemetryOtlpGrpcSpanCompleterSpec extends BaseJaegerSpec {
   it should "Send a span to jaeger" in forAll { (span: CompletedSpan.Builder, serviceName: String) =>
     val process = TraceProcess(serviceName)
 
-    val updatedSpan = span.copy(start = Instant.now(), end = Instant.now(), links = span.links)
+    val updatedSpan = span.copy(
+      start = Instant.now(),
+      end = Instant.now(),
+      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+    )
     val batch = Batch(Chunk(updatedSpan.build(serviceName)))
 
     testCompleter(

--- a/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporterSpec.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporterSpec.scala
@@ -15,8 +15,7 @@ class OpenTelemetryOtlpGrpcSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = process.attributes ++ span.attributes,
-            links = span.links,
+            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) => key == "ip" },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleterSpec.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleterSpec.scala
@@ -13,7 +13,11 @@ class OpenTelemetryOtlpHttpSpanCompleterSpec extends BaseJaegerSpec {
   it should "Send a span to jaeger" in forAll { (span: CompletedSpan.Builder, serviceName: String) =>
     val process = TraceProcess(serviceName)
 
-    val updatedSpan = span.copy(start = Instant.now(), end = Instant.now(), links = span.links)
+    val updatedSpan = span.copy(
+      start = Instant.now(),
+      end = Instant.now(),
+      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+    )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 
     testCompleter(

--- a/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanExporterSpec.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanExporterSpec.scala
@@ -15,8 +15,7 @@ class OpenTelemetryOtlpHttpSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = process.attributes ++ span.attributes,
-            links = span.links,
+            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) => key == "ip" },
             start = Instant.now(),
             end = Instant.now()
           )


### PR DESCRIPTION
I suddenly caught a failure in tests. It turned out that Jaeger automatically converts any tag with key "ip" from Long to String (eg. 2130706433 -> '127.0.0.1').

So I filter "ip" out.
