### PR TITLE
Proper shifting after async interop in CE2

### DIFF
--- a/modules/collector/src/main/scala-2.13/io/janstenpickle/trace4cats/collector/Collector.scala
+++ b/modules/collector/src/main/scala-2.13/io/janstenpickle/trace4cats/collector/Collector.scala
@@ -1,6 +1,6 @@
 package io.janstenpickle.trace4cats.collector
 
-import cats.effect.{Blocker, ConcurrentEffect, ExitCode, IO, Resource}
+import cats.effect.{Blocker, ConcurrentEffect, ContextShift, ExitCode, IO, Resource}
 import cats.implicits._
 import com.monovore.decline._
 import com.monovore.decline.effect._
@@ -35,7 +35,7 @@ object Collector
       }
     }
 
-  def others[F[_]: ConcurrentEffect](
+  def others[F[_]: ConcurrentEffect: ContextShift](
     configFile: String
   ): Resource[F, List[(String, List[(String, AttributeValue)], SpanExporter[F, Chunk])]] =
     for {

--- a/modules/opentelemetry-jaeger-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleter.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleter.scala
@@ -1,6 +1,6 @@
 package io.janstenpickle.trace4cats.opentelemetry.jaeger
 
-import cats.effect.{Concurrent, Resource, Timer}
+import cats.effect.{Concurrent, ContextShift, Resource, Timer}
 import fs2.Chunk
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -9,7 +9,7 @@ import io.janstenpickle.trace4cats.kernel.SpanCompleter
 import io.janstenpickle.trace4cats.model.TraceProcess
 
 object OpenTelemetryJaegerSpanCompleter {
-  def apply[F[_]: Concurrent: Timer](
+  def apply[F[_]: Concurrent: ContextShift: Timer](
     process: TraceProcess,
     host: String = "localhost",
     port: Int = 14250,

--- a/modules/opentelemetry-jaeger-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporter.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporter.scala
@@ -1,13 +1,13 @@
 package io.janstenpickle.trace4cats.opentelemetry.jaeger
 
 import cats.Foldable
-import cats.effect.{Async, Resource}
+import cats.effect.{Async, ContextShift, Resource}
 import io.janstenpickle.trace4cats.kernel.SpanExporter
 import io.janstenpickle.trace4cats.opentelemetry.common.OpenTelemetryGrpcSpanExporter
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter
 
 object OpenTelemetryJaegerSpanExporter {
-  def apply[F[_]: Async, G[_]: Foldable](
+  def apply[F[_]: Async: ContextShift, G[_]: Foldable](
     host: String = "localhost",
     port: Int = 14250
   ): Resource[F, SpanExporter[F, G]] =

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
@@ -1,6 +1,6 @@
 package io.janstenpickle.trace4cats.opentelemetry.otlp
 
-import cats.effect.{Concurrent, Resource, Timer}
+import cats.effect.{Concurrent, ContextShift, Resource, Timer}
 import fs2.Chunk
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -9,7 +9,7 @@ import io.janstenpickle.trace4cats.kernel.SpanCompleter
 import io.janstenpickle.trace4cats.model.TraceProcess
 
 object OpenTelemetryOtlpGrpcSpanCompleter {
-  def apply[F[_]: Concurrent: Timer](
+  def apply[F[_]: Concurrent: ContextShift: Timer](
     process: TraceProcess,
     host: String = "localhost",
     port: Int = 55680,

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
@@ -1,13 +1,13 @@
 package io.janstenpickle.trace4cats.opentelemetry.otlp
 
 import cats.Foldable
-import cats.effect.{Async, Resource}
+import cats.effect.{Async, ContextShift, Resource}
 import io.janstenpickle.trace4cats.kernel.SpanExporter
 import io.janstenpickle.trace4cats.opentelemetry.common.OpenTelemetryGrpcSpanExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 
 object OpenTelemetryOtlpGrpcSpanExporter {
-  def apply[F[_]: Async, G[_]: Foldable](
+  def apply[F[_]: Async: ContextShift, G[_]: Foldable](
     host: String = "localhost",
     port: Int = 55680
   ): Resource[F, SpanExporter[F, G]] =

--- a/modules/stackdriver-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverGrpcSpanCompleter.scala
+++ b/modules/stackdriver-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverGrpcSpanCompleter.scala
@@ -1,6 +1,6 @@
 package io.janstenpickle.trace4cats.stackdriver
 
-import cats.effect.{Concurrent, Resource, Timer}
+import cats.effect.{Concurrent, ContextShift, Resource, Timer}
 import com.google.auth.Credentials
 import fs2.Chunk
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, QueuedSpanCompleter}
@@ -12,7 +12,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.concurrent.duration._
 
 object StackdriverGrpcSpanCompleter {
-  def apply[F[_]: Concurrent: Timer](
+  def apply[F[_]: Concurrent: ContextShift: Timer](
     process: TraceProcess,
     projectId: String,
     credentials: Option[Credentials] = None,


### PR DESCRIPTION
I overlooked this when we were backporting things from the CE3 branch. This is mandatory in CE2: after `async` we must shift back. Otherwise, the continuation will perform in the grpc (netty) pool.

P.S. This is NOT needed in CE3, since `Async` automatically shifts back.