### PR TITLE
Drop sbt 0.13 slash syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val commonSettings = Seq(
   scmInfo := Some(
     ScmInfo(url("https://github.com/janstenpickle/trace4cats"), "scm:git:git@github.com:janstenpickle/trace4cats.git")
   ),
-  javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8"),
+  Compile / compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
   addCompilerPlugin(("org.typelevel" %% "kind-projector" % "0.11.3").cross(CrossVersion.patch)),
   libraryDependencies ++= Seq(Dependencies.cats, Dependencies.collectionCompat),
@@ -27,7 +27,7 @@ lazy val commonSettings = Seq(
       case _ => opts
     }
   },
-  fork in Test := true,
+  Test / fork := true,
   bintrayRepository := "trace4cats",
   releaseEarlyWith in Global := SonatypePublisher,
   credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials"),
@@ -45,7 +45,7 @@ lazy val publishSettings = commonSettings ++ Seq(
   pomIncludeRepository := { _ =>
     false
   },
-  publishArtifact in Test := false
+  Test / publishArtifact := false
 )
 
 lazy val graalSettings = Seq(
@@ -360,8 +360,8 @@ lazy val `opentelemetry-otlp-http-exporter` =
         (Dependencies.openTelemetryProto % "protobuf").intransitive(),
         Dependencies.scalapbJson
       ),
-      PB.protoSources in Compile += target.value / "protobuf_external",
-      PB.targets in Compile := Seq(scalapb.gen(grpc = false, lenses = false) -> (sourceManaged in Compile).value)
+      Compile / PB.protoSources += target.value / "protobuf_external",
+      Compile / PB.targets := Seq(scalapb.gen(grpc = false, lenses = false) -> (Compile / sourceManaged).value)
     )
     .dependsOn(model, kernel, `exporter-common`, `exporter-http`, `jaeger-integration-test` % "test->compile")
 
@@ -453,8 +453,8 @@ lazy val `avro-kafka-exporter` =
         Dependencies.log4cats
       ),
       libraryDependencies ++= (Dependencies.test ++ Seq(Dependencies.embeddedKafka)).map(_ % Test),
-      classLoaderLayeringStrategy in Test := ClassLoaderLayeringStrategy.ScalaLibrary,
-      classLoaderLayeringStrategy in Test := ClassLoaderLayeringStrategy.Flat
+      Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary,
+      Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
     )
     .dependsOn(model, kernel, `exporter-common`, avro, test % "test->compile")
 
@@ -782,8 +782,8 @@ lazy val collector = (project in file("modules/collector"))
     dockerBaseImage := "adoptopenjdk/openjdk15:alpine-jre",
     dockerExposedPorts += 7777,
     dockerExposedUdpPorts += 7777,
-    daemonUserUid in Docker := Some("9000"),
-    javaOptions in Universal ++= Seq(
+    Docker / daemonUserUid := Some("9000"),
+    Universal / javaOptions ++= Seq(
       "-Djava.net.preferIPv4Stack=true",
       "-J-XX:+UnlockExperimentalVMOptions",
       "-J-XX:MaxRAMPercentage=90"


### PR DESCRIPTION
This PR fixes warnings in sbt like this:
```
[info] /build.sbt:18: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
  javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8"),
               ^
/build.sbt:48: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
  publishArtifact in Test := false
  
  ```