### PR TITLE
Derivations via magnolia

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val model =
         Dependencies.enumeratum,
         Dependencies.enumeratumCats,
         Dependencies.commonsCodec,
-        Dependencies.kittens
+        Dependencies.magnolifyCats
       )
     )
 
@@ -300,7 +300,12 @@ lazy val `jaeger-thrift-exporter` =
     .settings(publishSettings)
     .settings(
       name := "trace4cats-jaeger-thrift-exporter",
-      libraryDependencies ++= Seq(Dependencies.catsEffect, Dependencies.fs2, Dependencies.jaegerThrift)
+      libraryDependencies ++= Seq(
+        Dependencies.alleyCats,
+        Dependencies.catsEffect,
+        Dependencies.fs2,
+        Dependencies.jaegerThrift
+      )
     )
     .dependsOn(model, kernel, `exporter-common`, `jaeger-integration-test` % "test->compile")
 

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/CompletedSpan.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/CompletedSpan.scala
@@ -41,7 +41,7 @@ object CompletedSpan {
   }
 
   implicit val instant: Eq[Instant] = Eq.fromUniversalEquals
-  implicit val eq: Eq[CompletedSpan] = cats.derived.semiauto.eq[CompletedSpan]
+  implicit val eq: Eq[CompletedSpan] = magnolify.cats.semiauto.EqDerivation[CompletedSpan]
 
   case class Builder(
     context: SpanContext,

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/Link.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/Link.scala
@@ -5,6 +5,6 @@ import cats.{Eq, Show}
 case class Link(traceId: TraceId, spanId: SpanId)
 
 object Link {
-  implicit val show: Show[Link] = cats.derived.semiauto.show[Link]
-  implicit val eq: Eq[Link] = cats.derived.semiauto.eq[Link]
+  implicit val show: Show[Link] = magnolify.cats.semiauto.ShowDerivation[Link]
+  implicit val eq: Eq[Link] = magnolify.cats.semiauto.EqDerivation[Link]
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/MetaTrace.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/MetaTrace.scala
@@ -8,5 +8,5 @@ case class MetaTrace(traceId: TraceId, spanId: SpanId)
 object MetaTrace {
   implicit val show: Show[MetaTrace] = Show.show(meta => show"[ ${meta.traceId} ${meta.spanId} ]")
 
-  implicit val eq: Eq[MetaTrace] = cats.derived.semiauto.eq
+  implicit val eq: Eq[MetaTrace] = magnolify.cats.semiauto.EqDerivation[MetaTrace]
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/Parent.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/Parent.scala
@@ -5,5 +5,5 @@ import cats.Eq
 case class Parent(spanId: SpanId, isRemote: Boolean)
 
 object Parent {
-  implicit val eq: Eq[Parent] = cats.derived.semiauto.eq[Parent]
+  implicit val eq: Eq[Parent] = magnolify.cats.semiauto.EqDerivation[Parent]
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanContext.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanContext.scala
@@ -51,5 +51,5 @@ object SpanContext {
     show"[ trace-id: ${c.traceId}, span-id: ${c.spanId}$parent$state, sampled: ${c.traceFlags.sampled}, remote: ${c.isRemote} ]"
   }
 
-  implicit val eq: Eq[SpanContext] = cats.derived.semiauto.eq[SpanContext]
+  implicit val eq: Eq[SpanContext] = magnolify.cats.semiauto.EqDerivation[SpanContext]
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceProcess.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceProcess.scala
@@ -10,5 +10,5 @@ object TraceProcess {
     show"[ service-name: ${process.serviceName}, attributes: ${process.attributes} ]"
   }
 
-  implicit val eq: Eq[TraceProcess] = cats.derived.semiauto.eq[TraceProcess]
+  implicit val eq: Eq[TraceProcess] = magnolify.cats.semiauto.EqDerivation[TraceProcess]
 }

--- a/modules/model/src/test/scala/io/janstenpickle/trace4cats/model/AttributeValueSpec.scala
+++ b/modules/model/src/test/scala/io/janstenpickle/trace4cats/model/AttributeValueSpec.scala
@@ -2,16 +2,13 @@ package io.janstenpickle.trace4cats.model
 
 import cats.Eval
 import cats.kernel.laws.discipline.SemigroupTests
-import org.scalacheck.{Arbitrary, ScalacheckShapeless}
+import magnolify.scalacheck.auto._
+import org.scalacheck.Arbitrary
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
-class AttributeValueSpec
-    extends AnyFunSuite
-    with ScalaCheckDrivenPropertyChecks
-    with FunSuiteDiscipline
-    with ScalacheckShapeless {
+class AttributeValueSpec extends AnyFunSuite with ScalaCheckDrivenPropertyChecks with FunSuiteDiscipline {
 
   implicit def evalArb[A: Arbitrary]: Arbitrary[Eval[A]] = Arbitrary(Arbitrary.arbitrary[A].map(Eval.now))
 

--- a/modules/stackdriver-http-exporter/src/test/scala/io/janstenpickle/trace4cats/stackdriver/oauth/CachedTokenProviderSpec.scala
+++ b/modules/stackdriver-http-exporter/src/test/scala/io/janstenpickle/trace4cats/stackdriver/oauth/CachedTokenProviderSpec.scala
@@ -3,7 +3,6 @@ package io.janstenpickle.trace4cats.stackdriver.oauth
 import cats.effect.laws.util.TestContext
 import cats.effect.{ContextShift, IO, Timer}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.ScalacheckShapeless._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -15,6 +14,7 @@ class CachedTokenProviderSpec extends AnyFlatSpec with Matchers with ScalaCheckD
   implicit lazy val ioTimer: Timer[IO] = ec.timer[IO]
 
   implicit val longArb: Arbitrary[Long] = Arbitrary(Gen.posNum[Long])
+  implicit val accessTokenArb: Arbitrary[AccessToken] = magnolify.scalacheck.semiauto.ArbitraryDerivation[AccessToken]
 
   it should "return a cached token when clock tick is less than expiry" in forAll {
     (token1: AccessToken, token2: AccessToken) =>

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfo.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfo.scala
@@ -16,7 +16,7 @@ object ErrorInfo {
   case class Unknown(code: Int, msg: String) extends ErrorInfo
   case object NoContent extends ErrorInfo
 
-  implicit val show: Show[ErrorInfo] = cats.derived.semiauto.show
+  implicit val show: Show[ErrorInfo] = magnolify.cats.semiauto.ShowDerivation[ErrorInfo]
 
   val endpointOutput: EndpointOutput[ErrorInfo] =
     oneOf[ErrorInfo](

--- a/modules/test/src/main/scala/io/janstenpickle/trace4cats/test/ArbitraryInstances.scala
+++ b/modules/test/src/main/scala/io/janstenpickle/trace4cats/test/ArbitraryInstances.scala
@@ -5,9 +5,11 @@ import java.time.Instant
 import cats.Eval
 import fs2.Chunk
 import io.janstenpickle.trace4cats.model._
-import org.scalacheck.{Arbitrary, Gen, ScalacheckShapeless}
+import org.scalacheck.{Arbitrary, Gen}
 
-trait ArbitraryInstances extends ScalacheckShapeless {
+trait ArbitraryInstances {
+  implicit def genArbitrary[T]: Arbitrary[T] = macro magnolify.scalacheck.auto.genArbitraryMacro[T]
+
   private def byteArray(length: Int) = Gen.listOfN(length, Arbitrary.arbByte.arbitrary).map(_.toArray)
 
   implicit val doubleArb: Arbitrary[Double] = Arbitrary(Gen.chooseNum(-1000.0, 1000.0).map(_ + 0.5))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,9 +21,9 @@ object Dependencies {
     val jaeger = "1.6.0"
     val jwt = "3.15.0"
     val kafka = "2.8.0"
-    val kittens = "2.2.2"
     val log4cats = "1.2.2"
     val logback = "1.2.3"
+    val mangolify = "0.4.3"
     val micronaut = "2.4.2"
     val natchez = "0.0.22"
     val openTelemetry = "1.1.0"
@@ -44,11 +44,11 @@ object Dependencies {
     val disciplineScalatest = "2.1.3"
     val discipline = "1.1.4"
     val scalaCheck = "1.15.3"
-    val scalaCheckShapeless = "1.2.5"
     val scalaTest = "3.2.8"
     val testContainers = "0.39.3"
   }
 
+  lazy val alleyCats = "org.typelevel"                         %% "alleycats-core"                  % Versions.cats
   lazy val cats = "org.typelevel"                              %% "cats-core"                       % Versions.cats
   lazy val catsEffect = "org.typelevel"                        %% "cats-effect"                     % Versions.catsEffect
   lazy val commonsCodec = "commons-codec"                       % "commons-codec"                   % Versions.commonsCodec
@@ -80,9 +80,9 @@ object Dependencies {
   lazy val jaegerThrift = "io.jaegertracing"                    % "jaeger-thrift"                   % Versions.jaeger
   lazy val jwt = "com.auth0"                                    % "java-jwt"                        % Versions.jwt
   lazy val kafka = "org.apache.kafka"                           % "kafka-clients"                   % Versions.kafka
-  lazy val kittens = "org.typelevel"                           %% "kittens"                         % Versions.kittens
   lazy val log4cats = "org.typelevel"                          %% "log4cats-slf4j"                  % Versions.log4cats
   lazy val logback = "ch.qos.logback"                           % "logback-classic"                 % Versions.logback
+  lazy val magnolifyCats = "com.spotify"                       %% "magnolify-cats"                  % Versions.mangolify
   lazy val micronautCore = "io.micronaut"                       % "micronaut-core"                  % Versions.micronaut
   lazy val natchez = "org.tpolecat"                            %% "natchez-core"                    % Versions.natchez
   lazy val openTelemetrySdk = "io.opentelemetry"                % "opentelemetry-sdk"               % Versions.openTelemetry
@@ -107,16 +107,15 @@ object Dependencies {
   lazy val vulcanEnumeratum = "com.github.fd4s"                %% "vulcan-enumeratum"               % Versions.vulcan
   lazy val zioInterop = "dev.zio"                              %% "zio-interop-cats"                % Versions.zioInterop
 
-  lazy val catsLaws = "org.typelevel"             %% "cats-laws"              % Versions.cats
-  lazy val catsEffectLaws = "org.typelevel"       %% "cats-effect-laws"       % Versions.catsEffect
-  lazy val catsTestkitScalatest = "org.typelevel" %% "cats-testkit-scalatest" % Versions.catsTestkitScalatest
-  lazy val disciplineScalatest = "org.typelevel"  %% "discipline-scalatest"   % Versions.disciplineScalatest
-  lazy val disciplineCore = "org.typelevel"       %% "discipline-core"        % Versions.discipline
-  lazy val scalacheck = "org.scalacheck"          %% "scalacheck"             % Versions.scalaCheck
-  lazy val scalacheckShapeless =
-    "com.github.alexarchambault"           %% "scalacheck-shapeless_1.14"      % Versions.scalaCheckShapeless
-  lazy val scalaTest = "org.scalatest"     %% "scalatest"                      % Versions.scalaTest
-  lazy val testContainers = "com.dimafeng" %% "testcontainers-scala-scalatest" % Versions.testContainers
+  lazy val catsLaws = "org.typelevel"             %% "cats-laws"                      % Versions.cats
+  lazy val catsEffectLaws = "org.typelevel"       %% "cats-effect-laws"               % Versions.catsEffect
+  lazy val catsTestkitScalatest = "org.typelevel" %% "cats-testkit-scalatest"         % Versions.catsTestkitScalatest
+  lazy val disciplineScalatest = "org.typelevel"  %% "discipline-scalatest"           % Versions.disciplineScalatest
+  lazy val disciplineCore = "org.typelevel"       %% "discipline-core"                % Versions.discipline
+  lazy val magnolifyScalacheck = "com.spotify"    %% "magnolify-scalacheck"           % Versions.mangolify
+  lazy val scalacheck = "org.scalacheck"          %% "scalacheck"                     % Versions.scalaCheck
+  lazy val scalaTest = "org.scalatest"            %% "scalatest"                      % Versions.scalaTest
+  lazy val testContainers = "com.dimafeng"        %% "testcontainers-scala-scalatest" % Versions.testContainers
 
   lazy val test =
     Seq(
@@ -125,8 +124,8 @@ object Dependencies {
       catsTestkitScalatest,
       disciplineScalatest,
       disciplineCore,
+      magnolifyScalacheck,
       scalacheck,
-      scalacheckShapeless,
       scalaTest
     )
 }


### PR DESCRIPTION
Switch from `kittens` and `scalacheck-shapeless` to `magnolify` as a more performant alternative.