### PR TITLE
Add attribute helpers

### DIFF
--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/attributes/EnvironmentAttributes.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/attributes/EnvironmentAttributes.scala
@@ -1,0 +1,28 @@
+package io.janstenpickle.trace4cats.attributes
+
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.janstenpickle.trace4cats.model.AttributeValue
+import io.janstenpickle.trace4cats.model.AttributeValue.StringValue
+
+import scala.jdk.CollectionConverters._
+
+object EnvironmentAttributes {
+  def apply[F[_]: Sync](): F[Map[String, AttributeValue]] = filterKeys(_ => true)
+
+  def excludeKeys[F[_]: Sync](excludeKeys: Set[String]): F[Map[String, AttributeValue]] = filterKeys(
+    !excludeKeys.contains(_)
+  )
+
+  def filterKeys[F[_]: Sync](filterKeys: String => Boolean): F[Map[String, AttributeValue]] =
+    Sync[F]
+      .delay(System.getenv())
+      .map(_.asScala.toMap.flatMap { case (k, v) =>
+        if (filterKeys(k)) Some(k -> StringValue(v)) else None
+      })
+
+  def includeKeys[F[_]: Sync](includeKeys: Set[String]): F[Map[String, AttributeValue]] =
+    Sync[F].delay(System.getenv()).map { env =>
+      includeKeys.flatMap(k => Option(env.get(k)).map(v => k -> StringValue(v))).toMap
+    }
+}

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/attributes/HostAttributes.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/attributes/HostAttributes.scala
@@ -1,0 +1,20 @@
+package io.janstenpickle.trace4cats.attributes
+
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import io.janstenpickle.trace4cats.model.AttributeValue.StringValue
+import io.janstenpickle.trace4cats.model.{AttributeValue, SemanticAttributeKeys}
+
+import java.net.InetAddress
+
+object HostAttributes {
+  def apply[F[_]: Sync]: F[Map[String, AttributeValue]] =
+    for {
+      inetAddress <- Sync[F].delay(InetAddress.getLocalHost)
+      ipv4 <- Sync[F].delay(Option(inetAddress.getHostAddress))
+      hostname <- Sync[F].delay(Option(inetAddress.getCanonicalHostName))
+    } yield ipv4.map(ip => SemanticAttributeKeys.serviceIpv4 -> StringValue(ip)).toMap ++ hostname.map(host =>
+      SemanticAttributeKeys.serviceHostname -> StringValue(host)
+    )
+}

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/attributes/SystemPropertyAttributes.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/attributes/SystemPropertyAttributes.scala
@@ -1,0 +1,28 @@
+package io.janstenpickle.trace4cats.attributes
+
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.janstenpickle.trace4cats.model.AttributeValue
+import io.janstenpickle.trace4cats.model.AttributeValue.StringValue
+
+import scala.jdk.CollectionConverters._
+
+object SystemPropertyAttributes {
+  def apply[F[_]: Sync](): F[Map[String, AttributeValue]] = filterKeys(_ => true)
+
+  def excludeKeys[F[_]: Sync](excludeKeys: Set[String]): F[Map[String, AttributeValue]] = filterKeys(
+    !excludeKeys.contains(_)
+  )
+
+  def filterKeys[F[_]: Sync](filter: String => Boolean): F[Map[String, AttributeValue]] =
+    Sync[F].delay(System.getProperties).map { properties =>
+      val keys = properties.stringPropertyNames().asScala.filter(filter)
+
+      keys.map(k => k -> StringValue(properties.getProperty(k))).toMap
+    }
+
+  def includeKeys[F[_]: Sync](includeKeys: Set[String]): F[Map[String, AttributeValue]] =
+    Sync[F].delay(System.getProperties).map { properties =>
+      includeKeys.flatMap(k => Option(properties.getProperty(k)).map(v => k -> StringValue(v))).toMap
+    }
+}

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/TraceProcessAttributes.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/TraceProcessAttributes.scala
@@ -1,0 +1,16 @@
+package io.janstenpickle.trace4cats.example
+
+import cats.effect.{ExitCode, IO, IOApp}
+import io.janstenpickle.trace4cats.attributes.{EnvironmentAttributes, HostAttributes, SystemPropertyAttributes}
+import io.janstenpickle.trace4cats.model.TraceProcessBuilder
+
+object TraceProcessAttributes extends IOApp {
+  override def run(args: List[String]): IO[ExitCode] =
+    TraceProcessBuilder("some-service")
+      .withAttributes(EnvironmentAttributes.includeKeys[IO](Set("HOME")))
+      .withAttributes(SystemPropertyAttributes.filterKeys[IO](_.contains("xyz")))
+      .withAttributes(HostAttributes[IO])
+      .build
+      .flatMap(attrs => IO(println(attrs)))
+      .as(ExitCode.Success)
+}

--- a/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/ContinuationSpan.scala
+++ b/modules/fs2/src/main/scala/io/janstenpickle/trace4cats/fs2/ContinuationSpan.scala
@@ -25,6 +25,8 @@ object ContinuationSpan {
 
       override def putAll(fields: (String, AttributeValue)*): G[Unit] = spanK.putAll(fields: _*)
 
+      override def putAll(fields: Map[String, AttributeValue]): G[Unit] = spanK.putAll(fields)
+
       override def setStatus(spanStatus: SpanStatus): G[Unit] = spanK.setStatus(spanStatus)
 
       override def addLink(link: Link): G[Unit] = spanK.addLink(link)

--- a/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/ClientTracer.scala
+++ b/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/ClientTracer.scala
@@ -6,7 +6,7 @@ import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.Provide
 import io.janstenpickle.trace4cats.base.optics.{Getter, Lens}
 import io.janstenpickle.trace4cats.http4s.common.{Http4sHeaders, Http4sSpanNamer, Http4sStatusMapping, Request_}
-import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders}
+import io.janstenpickle.trace4cats.model.{SampleDecision, SpanKind, TraceHeaders}
 import org.http4s.Request
 import org.http4s.client.{Client, UnexpectedStatus}
 
@@ -35,11 +35,19 @@ object ClientTracer {
               val headers = headersGetter.get(childCtx)
               val req = request.putHeaders(Http4sHeaders.converter.to(headers).toList: _*)
 
-              client
-                .run(req.mapK(P.provideK(childCtx)))
-                .evalTap { resp =>
-                  childSpan.setStatus(Http4sStatusMapping.toSpanStatus(resp.status))
-                }
+              for {
+                _ <- Resource.eval(
+                  // only extract request attributes if the span is sampled as the address matching can be quite expensive
+                  if (childSpan.context.traceFlags.sampled == SampleDecision.Include)
+                    childSpan.putAll(Http4sClientRequest.toAttributes(request))
+                  else Applicative[F].unit
+                )
+                res <- client
+                  .run(req.mapK(P.provideK(childCtx)))
+                  .evalTap { resp =>
+                    childSpan.setStatus(Http4sStatusMapping.toSpanStatus(resp.status))
+                  }
+              } yield res
             }
             .mapK(P.liftK)
             .map(_.mapK(P.liftK))

--- a/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/Http4sClientRequest.scala
+++ b/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/Http4sClientRequest.scala
@@ -1,0 +1,17 @@
+package io.janstenpickle.trace4cats.http4s.client
+
+import io.janstenpickle.trace4cats.http4s.common.Request_
+import io.janstenpickle.trace4cats.model.AttributeValue.{LongValue, StringValue}
+import io.janstenpickle.trace4cats.model.{AttributeValue, SemanticAttributeKeys}
+import org.http4s.Uri
+
+object Http4sClientRequest {
+  def toAttributes(req: Request_): Map[String, AttributeValue] =
+    req.uri.host.map {
+      case address @ Uri.Ipv4Address(_, _, _, _) =>
+        SemanticAttributeKeys.remoteServiceIpv4 -> StringValue(address.toString())
+      case address @ Uri.Ipv6Address(_, _, _, _, _, _, _, _) =>
+        SemanticAttributeKeys.remoteServiceIpv6 -> StringValue(address.toString())
+      case Uri.RegName(host) => SemanticAttributeKeys.remoteServiceHostname -> StringValue(host.toString)
+    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.servicePort -> LongValue(port.toLong))
+}

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SemanticAttributeKeys.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SemanticAttributeKeys.scala
@@ -1,0 +1,25 @@
+package io.janstenpickle.trace4cats.model
+
+object SemanticAttributeKeys {
+  // local service attributes
+  private final val service = "service."
+  final val servicePort: String = service + "port"
+  final val serviceIpv4: String = service + "ipv4"
+  final val serviceIpv6: String = service + "ipv6"
+  final val serviceHostname: String = service + "hostname"
+
+  // remote service attributes
+  private final val remote = "remote."
+  final val remoteServicePort: String = remote + servicePort
+  final val remoteServiceIpv4: String = remote + serviceIpv4
+  final val remoteServiceIpv6: String = remote + serviceIpv6
+  final val remoteServiceHostname: String = remote + serviceHostname
+
+  // http attributes
+  private final val http = "http."
+  final val httpMethod: String = http + "method"
+  final val httpUrl: String = http + "url"
+  final val httpStatusCode: String = http + "status_code"
+  final val httpStatusMessage: String = http + "status_message"
+
+}

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceProcessBuilder.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/TraceProcessBuilder.scala
@@ -1,0 +1,32 @@
+package io.janstenpickle.trace4cats.model
+
+import cats.{Applicative, Monad}
+import cats.data.Chain
+import cats.syntax.foldable._
+import cats.syntax.functor._
+
+case class TraceProcessBuilder[F[_]] private (
+  serviceName: String,
+  private val lazyAttributes: Chain[F[Map[String, AttributeValue]]]
+) {
+  def withAttribute(key: String, value: AttributeValue)(implicit F: Applicative[F]): TraceProcessBuilder[F] =
+    withAttributes(Map(key -> value))
+
+  def withAttributes(attrs: (String, AttributeValue)*)(implicit F: Applicative[F]): TraceProcessBuilder[F] =
+    withAttributes(attrs.toMap)
+
+  def withAttributes(attrs: Map[String, AttributeValue])(implicit F: Applicative[F]): TraceProcessBuilder[F] =
+    this.copy(serviceName, lazyAttributes.append(F.pure(attrs)))
+
+  def withAttributes(attrs: F[Map[String, AttributeValue]]): TraceProcessBuilder[F] =
+    this.copy(serviceName, lazyAttributes.append(attrs))
+
+  def build(implicit F: Monad[F]): F[TraceProcess] =
+    lazyAttributes
+      .foldLeftM(Map.empty[String, AttributeValue]) { case (acc, attrs) => attrs.map(acc ++ _) }
+      .map(attrs => TraceProcess(serviceName, attrs))
+}
+
+object TraceProcessBuilder {
+  def apply[F[_]](serviceName: String): TraceProcessBuilder[F] = new TraceProcessBuilder[F](serviceName, Chain.empty)
+}

--- a/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpRequest.scala
+++ b/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpRequest.scala
@@ -1,0 +1,26 @@
+package io.janstenpickle.trace4cats.sttp.client3
+
+import io.janstenpickle.trace4cats.model.AttributeValue.{LongValue, StringValue}
+import io.janstenpickle.trace4cats.model.{AttributeValue, SemanticAttributeKeys}
+import sttp.client3.Request
+
+object SttpRequest {
+  //credit : Regular Expressions Cookbook by Steven Levithan, Jan Goyvaerts
+  private final val ipv4Regex =
+    "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$".r
+
+  //credit : Regular Expressions Cookbook by Steven Levithan, Jan Goyvaerts
+  private final val ipv6Regex =
+    "^(?:(?:(?:[A-F0-9]{1,4}:){6}|(?=(?:[A-F0-9]{0,4}:){0,6}(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$)(([0-9A-F]{1,4}:){0,5}|:)((:[0-9A-F]{1,4}){1,5}:|:))(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:))$".r
+
+  def toAttributes[T, R](req: Request[T, R]): Map[String, AttributeValue] =
+    req.uri.host.map { host =>
+      val key = host.toUpperCase match {
+        case ipv4Regex(_*) => SemanticAttributeKeys.remoteServiceIpv4
+        case ipv6Regex(_*) => SemanticAttributeKeys.remoteServiceIpv6
+        case _ => SemanticAttributeKeys.remoteServiceHostname
+      }
+
+      key -> StringValue(host)
+    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.servicePort -> LongValue(port.toLong))
+}


### PR DESCRIPTION
CE2 version of #466 

- Introduces semantic conventions for attribute names, these can
  be used with exporters like Zipkin where more information is
  useful/required
- Add helpers for extracting attributes from the local system
  such as hostname, IP address, environment variables and
  system properties
- Create an optional builder for `TraceProcess` that allows
  attributes to be resolved by side affect to be added to the
  `TraceProcess` via a fluent API
- Updated Http4s client and server wrappers to capture service
  information such as local and remote service when making
  requests
- Updated Sttp client to capture request information for the
  remote service