### PR TITLE
Fix URI attribute helpers

### DIFF
--- a/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/Http4sClientRequest.scala
+++ b/modules/http4s-client/src/main/scala/io/janstenpickle/trace4cats/http4s/client/Http4sClientRequest.scala
@@ -7,11 +7,12 @@ import org.http4s.Uri
 
 object Http4sClientRequest {
   def toAttributes(req: Request_): Map[String, AttributeValue] =
-    req.uri.host.map {
-      case address @ Uri.Ipv4Address(_, _, _, _) =>
-        SemanticAttributeKeys.remoteServiceIpv4 -> StringValue(address.toString())
-      case address @ Uri.Ipv6Address(_, _, _, _, _, _, _, _) =>
-        SemanticAttributeKeys.remoteServiceIpv6 -> StringValue(address.toString())
-      case Uri.RegName(host) => SemanticAttributeKeys.remoteServiceHostname -> StringValue(host.toString)
-    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.servicePort -> LongValue(port.toLong))
+    req.uri.host.map { host =>
+      val key = host match {
+        case _: Uri.Ipv4Address => SemanticAttributeKeys.remoteServiceIpv4
+        case _: Uri.Ipv6Address => SemanticAttributeKeys.remoteServiceIpv6
+        case _: Uri.RegName => SemanticAttributeKeys.remoteServiceHostname
+      }
+      key -> StringValue(host.value)
+    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.remoteServicePort -> LongValue(port.toLong))
 }

--- a/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/client/SttpRequest.scala
+++ b/modules/sttp-client/src/main/scala/io/janstenpickle/trace4cats/sttp/client/SttpRequest.scala
@@ -21,7 +21,7 @@ object SttpRequest {
     }
 
     Map(key -> StringValue(req.uri.host)) ++ req.uri.port.map(port =>
-      SemanticAttributeKeys.servicePort -> LongValue(port.toLong)
+      SemanticAttributeKeys.remoteServicePort -> LongValue(port.toLong)
     )
   }
 }

--- a/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpRequest.scala
+++ b/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpRequest.scala
@@ -22,5 +22,5 @@ object SttpRequest {
       }
 
       key -> StringValue(host)
-    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.servicePort -> LongValue(port.toLong))
+    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.remoteServicePort -> LongValue(port.toLong))
 }


### PR DESCRIPTION
* Replace `.toString` to `.value` (a better representation).
* Replace `servicePort` to `remoteServicePort` in clients