### PR TITLE
Fix flaky Jaeger tests

### DIFF
--- a/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanCompleterSpec.scala
+++ b/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanCompleterSpec.scala
@@ -14,7 +14,10 @@ class JaegerSpanCompleterSpec extends BaseJaegerSpec {
     val updatedSpan = span.copy(
       start = Instant.now(),
       end = Instant.now(),
-      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+      attributes = span.attributes
+        .filterNot { case (key, _) =>
+          excludedTagKeys.contains(key)
+        }
     )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 

--- a/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporterSpec.scala
+++ b/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporterSpec.scala
@@ -15,7 +15,9 @@ class JaegerSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) => key == "ip" },
+            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) =>
+              excludedTagKeys.contains(key)
+            },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/package.scala
+++ b/modules/jaeger-thrift-exporter/src/test/scala/io/janstenpickle/trace4cats/jaeger/package.scala
@@ -1,0 +1,5 @@
+package io.janstenpickle.trace4cats
+
+package object jaeger {
+  val excludedTagKeys: Set[String] = Set("ip")
+}

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleterSpec.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleterSpec.scala
@@ -16,7 +16,9 @@ class OpenTelemetryJaegerSpanCompleterSpec extends BaseJaegerSpec {
     val updatedSpan = span.copy(
       start = Instant.now(),
       end = Instant.now(),
-      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+      attributes = span.attributes.filterNot { case (key, _) =>
+        excludedTagKeys.contains(key)
+      },
     )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporterSpec.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporterSpec.scala
@@ -14,7 +14,10 @@ class OpenTelemetryJaegerSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = (process.attributes ++ span.allAttributes).filterNot { case (key, _) => key == "ip" },
+            attributes = (process.attributes ++ span.allAttributes)
+              .filterNot { case (key, _) =>
+                excludedTagKeys.contains(key)
+              },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/package.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/package.scala
@@ -29,4 +29,6 @@ package object jaeger {
   val processTags: TraceProcess => Map[String, AttributeValue] = p => Map("service.name" -> p.serviceName)
 
   val additionalTags: Map[String, AttributeValue] = Map("otel.library.name" -> "trace4cats")
+
+  val excludedTagKeys: Set[String] = Set("ip")
 }

--- a/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleterSpec.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleterSpec.scala
@@ -16,7 +16,9 @@ class OpenTelemetryOtlpGrpcSpanCompleterSpec extends BaseJaegerSpec {
     val updatedSpan = span.copy(
       start = Instant.now(),
       end = Instant.now(),
-      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+      attributes = span.attributes.filterNot { case (key, _) =>
+        excludedTagKeys.contains(key)
+      }
     )
     val batch = Batch(Chunk(updatedSpan.build(serviceName)))
 

--- a/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporterSpec.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporterSpec.scala
@@ -15,7 +15,10 @@ class OpenTelemetryOtlpGrpcSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) => key == "ip" },
+            attributes = (process.attributes ++ span.attributes)
+              .filterNot { case (key, _) =>
+                excludedTagKeys.contains(key)
+              },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/package.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/package.scala
@@ -11,4 +11,6 @@ package object otlp {
   val processTags: TraceProcess => Map[String, AttributeValue] = _ => Map.empty
 
   val additionalTags: Map[String, AttributeValue] = Map("otel.library.name" -> "trace4cats")
+
+  val excludedTagKeys: Set[String] = Set("ip")
 }

--- a/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleterSpec.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleterSpec.scala
@@ -16,7 +16,9 @@ class OpenTelemetryOtlpHttpSpanCompleterSpec extends BaseJaegerSpec {
     val updatedSpan = span.copy(
       start = Instant.now(),
       end = Instant.now(),
-      attributes = span.attributes.filterNot { case (key, _) => key == "ip" }
+      attributes = span.attributes.filterNot { case (key, _) =>
+        excludedTagKeys.contains(key)
+      }
     )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 

--- a/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanExporterSpec.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanExporterSpec.scala
@@ -15,7 +15,10 @@ class OpenTelemetryOtlpHttpSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = (process.attributes ++ span.attributes).filterNot { case (key, _) => key == "ip" },
+            attributes = (process.attributes ++ span.attributes)
+              .filterNot { case (key, _) =>
+                excludedTagKeys.contains(key)
+              },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/package.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/test/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/package.scala
@@ -11,4 +11,6 @@ package object otlp {
   val processTags: TraceProcess => Map[String, AttributeValue] = _ => Map.empty
 
   val additionalTags: Map[String, AttributeValue] = Map("otel.library.name" -> "trace4cats")
+
+  val excludedTagKeys: Set[String] = Set("ip")
 }

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleterSpec.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleterSpec.scala
@@ -13,7 +13,13 @@ class ZipkinHttpSpanCompleterSpec extends BaseJaegerSpec {
   it should "Send a span to Zipkin" in forAll { (span: CompletedSpan.Builder, serviceName: String) =>
     val process = TraceProcess(serviceName)
 
-    val updatedSpan = span.copy(start = Instant.now(), end = Instant.now(), attributes = span.attributes)
+    val updatedSpan = span.copy(
+      start = Instant.now(),
+      end = Instant.now(),
+      attributes = span.attributes.filterNot { case (key, _) =>
+        excludedTagKeys.contains(key)
+      }
+    )
     val batch = Batch(Chunk(updatedSpan.build(process)))
 
     testCompleter(

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporterSpec.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanExporterSpec.scala
@@ -15,7 +15,10 @@ class ZipkinHttpSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = process.attributes ++ span.attributes,
+            attributes = (process.attributes ++ span.attributes)
+              .filterNot { case (key, _) =>
+                excludedTagKeys.contains(key)
+              },
             start = Instant.now(),
             end = Instant.now()
           )

--- a/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/package.scala
+++ b/modules/zipkin-http-exporter/src/test/scala/io/janstenpickle/trace4cats/zipkin/package.scala
@@ -23,4 +23,6 @@ package object zipkin {
         case (k, AttributeValue.BooleanValue(value)) if k == "error" => JaegerTag.BoolTag(k, value.value)
         case (k, v) => JaegerTag.StringTag(k, v.show)
       }
+
+  val excludedTagKeys: Set[String] = Set("lc")
 }


### PR DESCRIPTION
Jaeger automatically transforms some tags, so they can't be found in response in tests.