### PR TITLE
Scala 3 preparations: enumeratum and better-monadic-for

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,8 +158,6 @@ lazy val model =
       libraryDependencies ++= Dependencies.test.map(_ % Test),
       libraryDependencies ++= Seq(
         Dependencies.catsEffectKernel,
-        Dependencies.enumeratum,
-        Dependencies.enumeratumCats,
         Dependencies.commonsCodec,
         Dependencies.kittens,
         Dependencies.caseInsensitive
@@ -266,10 +264,7 @@ lazy val `base-zio` =
 lazy val avro =
   (project in file("modules/avro"))
     .settings(publishSettings)
-    .settings(
-      name := "trace4cats-avro",
-      libraryDependencies ++= Seq(Dependencies.vulcan, Dependencies.vulcanGeneric, Dependencies.vulcanEnumeratum)
-    )
+    .settings(name := "trace4cats-avro", libraryDependencies ++= Seq(Dependencies.vulcan, Dependencies.vulcanGeneric))
     .dependsOn(model)
 
 lazy val `log-exporter` =
@@ -376,7 +371,6 @@ lazy val `stackdriver-http-exporter` =
       libraryDependencies ++= Seq(
         Dependencies.circeGeneric,
         Dependencies.circeParser,
-        Dependencies.enumeratumCirce,
         Dependencies.http4sClient,
         Dependencies.http4sCirce,
         Dependencies.http4sBlazeClient,

--- a/modules/avro-exporter/src/main/scala/io/janstenpickle/trace4cats/avro/AvroSpanCompleter.scala
+++ b/modules/avro-exporter/src/main/scala/io/janstenpickle/trace4cats/avro/AvroSpanCompleter.scala
@@ -15,11 +15,9 @@ object AvroSpanCompleter {
     port: Int = agentPort,
     config: CompleterConfig = CompleterConfig(),
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- AvroSpanExporter.udp[F, Chunk](host, port)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      AvroSpanExporter.udp[F, Chunk](host, port).flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 
   def tcp[F[_]: Async](
     process: TraceProcess,
@@ -27,10 +25,8 @@ object AvroSpanCompleter {
     port: Int = agentPort,
     config: CompleterConfig = CompleterConfig(),
   ): Resource[F, SpanCompleter[F]] = {
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- AvroSpanExporter.tcp[F, Chunk](host, port)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      AvroSpanExporter.tcp[F, Chunk](host, port).flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
   }
 }

--- a/modules/collector-common/src/main/scala-2.13/io/janstenpickle/trace4cats/collector/common/CommonCollector.scala
+++ b/modules/collector-common/src/main/scala-2.13/io/janstenpickle/trace4cats/collector/common/CommonCollector.scala
@@ -191,7 +191,7 @@ object CommonCollector {
         Tracing.exporter[F](traceSampler, "Collector Combined", allExporters.map(_._1), exporterTraceAttrs, process, _)
       )
 
-      samplingPipe: Pipe[F, CompletedSpan, CompletedSpan] <- Sampling.pipe[F](config.sampling)
+      samplingPipe <- Sampling.pipe[F](config.sampling)
 
       tracingPipe = Tracing.pipe[F](traceSampler, process, config.listener, config.kafkaListener)
 

--- a/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpanCompleter.scala
+++ b/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpanCompleter.scala
@@ -33,9 +33,9 @@ object DataDogSpanCompleter {
     port: Int = 8126,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(DataDogSpanExporter[F, Chunk](client, host, port))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      Resource
+        .eval(DataDogSpanExporter[F, Chunk](client, host, port))
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/dynamic-sampling/src/main/scala/io/janstenpickle/trace4cats/sampling/dynamic/HotSwapSpanSampler.scala
+++ b/modules/dynamic-sampling/src/main/scala/io/janstenpickle/trace4cats/sampling/dynamic/HotSwapSpanSampler.scala
@@ -20,7 +20,8 @@ object HotSwapSpanSampler {
     id: A,
     initial: Resource[F, SpanSampler[F]]
   ): Resource[F, HotSwapSpanSampler[F, A]] = for {
-    (hotswap, sampler) <- Hotswap(initial)
+    hotSwapAndSampler <- Hotswap(initial)
+    (hotswap, sampler) = hotSwapAndSampler
     current <- Resource.eval(Ref.of((sampler, id)))
   } yield new HotSwapSpanSampler[F, A] {
     def updateSampler(newId: A, samplerResource: Resource[F, SpanSampler[F]]): F[Boolean] =

--- a/modules/dynamic-sampling/src/main/scala/io/janstenpickle/trace4cats/sampling/dynamic/PollingSpanSampler.scala
+++ b/modules/dynamic-sampling/src/main/scala/io/janstenpickle/trace4cats/sampling/dynamic/PollingSpanSampler.scala
@@ -3,6 +3,7 @@ package io.janstenpickle.trace4cats.sampling.dynamic
 import cats.effect.kernel.syntax.spawn._
 import cats.effect.kernel.{Resource, Temporal}
 import cats.kernel.Eq
+import cats.syntax.all._
 import fs2.Stream
 import io.janstenpickle.trace4cats.kernel.SpanSampler
 
@@ -21,10 +22,9 @@ object PollingSpanSampler {
         _ <- Stream.eval(sampler.updateSampler(id, samplerResource))
       } yield ()
 
-    for {
-      (id, samplerResource) <- Resource.eval(configuredSampler)
-      sampler <- HotSwapSpanSampler.create(id, samplerResource)
-      _ <- configPoller(sampler).compile.drain.background
-    } yield sampler
+    Resource
+      .eval(configuredSampler)
+      .flatMap((HotSwapSpanSampler.create[F, A] _).tupled)
+      .flatTap(configPoller(_).compile.drain.background)
   }
 }

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/AdvancedExample.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/AdvancedExample.scala
@@ -1,11 +1,11 @@
 package io.janstenpickle.trace4cats.example
 
-import cats.effect.{ExitCode, IO, IOApp, Resource}
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import cats.effect.{ExitCode, IO, IOApp}
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.model.{SpanKind, SpanStatus, TraceProcess}
 import io.janstenpickle.trace4cats.rate.sampling.RateSpanSampler
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
 
@@ -14,9 +14,8 @@ import scala.concurrent.duration._
   * as the simple example call tree.
   */
 object AdvancedExample extends IOApp {
-  override def run(args: List[String]): IO[ExitCode] =
+  override def run(args: List[String]): IO[ExitCode] = Slf4jLogger.create[IO].flatMap { implicit logger: Logger[IO] =>
     (for {
-      implicit0(logger: Logger[IO]) <- Resource.eval(Slf4jLogger.create[IO])
       completer <- AllCompleters[IO](TraceProcess("test"))
 
       // Set up rate sampler
@@ -26,4 +25,5 @@ object AdvancedExample extends IOApp {
       root <- Span.root[IO]("root", SpanKind.Client, rateSampler, completer)
       child <- root.child("child", SpanKind.Server)
     } yield child).use(_.setStatus(SpanStatus.Internal("Error"))).as(ExitCode.Success)
+  }
 }

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/AttributeFiltering.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/AttributeFiltering.scala
@@ -1,11 +1,9 @@
 package io.janstenpickle.trace4cats.example
 
 import cats.data.{NonEmptyMap, NonEmptySet}
-import cats.effect.{ExitCode, IO, IOApp, Resource}
+import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.semigroup._
 import fs2.Chunk
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, QueuedSpanCompleter}
 import io.janstenpickle.trace4cats.avro.AvroSpanExporter
@@ -13,11 +11,12 @@ import io.janstenpickle.trace4cats.filtering.AttributeFilter._
 import io.janstenpickle.trace4cats.filtering.{AttributeFilter, AttributeFilteringExporter}
 import io.janstenpickle.trace4cats.kernel.SpanSampler
 import io.janstenpickle.trace4cats.model.{SpanKind, SpanStatus, TraceProcess}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object AttributeFiltering extends IOApp {
-  override def run(args: List[String]): IO[ExitCode] =
+  override def run(args: List[String]): IO[ExitCode] = Slf4jLogger.create[IO].flatMap { implicit logger: Logger[IO] =>
     (for {
-      implicit0(logger: Logger[IO]) <- Resource.eval(Slf4jLogger.create[IO])
       exporter <- AvroSpanExporter.udp[IO, Chunk]()
 
       nameFilter = AttributeFilter.names(NonEmptySet.of("some.attribute.name", "some.other.name"))
@@ -34,4 +33,5 @@ object AttributeFiltering extends IOApp {
       root <- Span.root[IO]("root", SpanKind.Client, SpanSampler.always, completer)
       child <- root.child("child", SpanKind.Server)
     } yield child).use(_.setStatus(SpanStatus.Internal("Error"))).as(ExitCode.Success)
+  }
 }

--- a/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/TailSampling.scala
+++ b/modules/example/src/main/scala/io/janstenpickle/trace4cats/example/TailSampling.scala
@@ -18,9 +18,8 @@ import io.janstenpickle.trace4cats.sampling.tail.{TailSamplingSpanExporter, Tail
 import scala.concurrent.duration._
 
 object TailSampling extends IOApp {
-  override def run(args: List[String]): IO[ExitCode] =
+  override def run(args: List[String]): IO[ExitCode] = Slf4jLogger.create[IO].flatMap { implicit logger: Logger[IO] =>
     (for {
-      implicit0(logger: Logger[IO]) <- Resource.eval(Slf4jLogger.create[IO])
       exporter <- AvroSpanExporter.udp[IO, Chunk]()
 
       nameSampleDecisionStore <-
@@ -45,4 +44,5 @@ object TailSampling extends IOApp {
       root <- Span.root[IO]("root", SpanKind.Client, SpanSampler.always, completer)
       child <- root.child("child", SpanKind.Server)
     } yield child).use(_.setStatus(SpanStatus.Internal("Error"))).as(ExitCode.Success)
+  }
 }

--- a/modules/jaeger-thrift-exporter/src/main/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanCompleter.scala
+++ b/modules/jaeger-thrift-exporter/src/main/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanCompleter.scala
@@ -22,9 +22,8 @@ object JaegerSpanCompleter {
     config: CompleterConfig = CompleterConfig(),
     blocker: Option[ExecutionContext] = None
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- JaegerSpanExporter[F, Chunk](Some(process), host, port, blocker)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      JaegerSpanExporter[F, Chunk](Some(process), host, port, blocker)
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanKind.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanKind.scala
@@ -1,15 +1,15 @@
 package io.janstenpickle.trace4cats.model
 
-import enumeratum.EnumEntry.Uppercase
-import enumeratum._
+import cats.{Order, Show}
 
-sealed trait SpanKind extends EnumEntry
-object SpanKind extends Enum[SpanKind] with CatsEnum[SpanKind] {
-  override def values = findValues
+sealed abstract class SpanKind(val entryName: String)
+object SpanKind {
+  case object Server extends SpanKind("SERVER")
+  case object Client extends SpanKind("CLIENT")
+  case object Producer extends SpanKind("PRODUCER")
+  case object Consumer extends SpanKind("CONSUMER")
+  case object Internal extends SpanKind("INTERNAL")
 
-  case object Server extends SpanKind with Uppercase
-  case object Client extends SpanKind with Uppercase
-  case object Producer extends SpanKind with Uppercase
-  case object Consumer extends SpanKind with Uppercase
-  case object Internal extends SpanKind with Uppercase
+  implicit val order: Order[SpanKind] = Order.by(_.entryName)
+  implicit val show: Show[SpanKind] = Show.show(_.entryName)
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanStatus.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanStatus.scala
@@ -76,6 +76,12 @@ object SpanStatus {
     override lazy val isOk: Boolean = false
   }
 
-  implicit val eq: Eq[SpanStatus] = Eq.by(_.canonicalCode)
-  implicit val show: Show[SpanStatus] = Show.show(_.entryName)
+  implicit val eq: Eq[SpanStatus] = Eq.by {
+    case s @ Internal(msg) => (s.canonicalCode, Some(msg))
+    case s => (s.canonicalCode, None)
+  }
+  implicit val show: Show[SpanStatus] = Show.show {
+    case s @ Internal(msg) => s"${s.entryName}($msg)"
+    case s => s.entryName
+  }
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanStatus.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanStatus.scala
@@ -1,81 +1,81 @@
 package io.janstenpickle.trace4cats.model
 
-import enumeratum.EnumEntry.Camelcase
-import enumeratum._
+import cats.{Eq, Show}
 
-sealed trait SpanStatus extends EnumEntry {
+sealed abstract class SpanStatus(val entryName: String) {
   def canonicalCode: Int
   def isOk: Boolean
 }
-object SpanStatus extends Enum[SpanStatus] with CatsEnum[SpanStatus] {
-  override def values = findValues
-
-  case object Ok extends SpanStatus with Camelcase {
+object SpanStatus {
+  case object Ok extends SpanStatus("Ok") {
     override lazy val canonicalCode: Int = 0
     override lazy val isOk: Boolean = true
   }
-  case object Cancelled extends SpanStatus with Camelcase {
+  case object Cancelled extends SpanStatus("Cancelled") {
     override lazy val canonicalCode: Int = 1
     override lazy val isOk: Boolean = false
   }
-  case object Unknown extends SpanStatus with Camelcase {
+  case object Unknown extends SpanStatus("Unknown") {
     override lazy val canonicalCode: Int = 2
     override lazy val isOk: Boolean = false
   }
-  case object InvalidArgument extends SpanStatus with Camelcase {
+  case object InvalidArgument extends SpanStatus("InvalidArgument") {
     override lazy val canonicalCode: Int = 3
     override lazy val isOk: Boolean = false
   }
-  case object DeadlineExceeded extends SpanStatus with Camelcase {
+  case object DeadlineExceeded extends SpanStatus("DeadlineExceeded") {
     override lazy val canonicalCode: Int = 4
     override lazy val isOk: Boolean = false
   }
-  case object NotFound extends SpanStatus with Camelcase {
+  case object NotFound extends SpanStatus("NotFound") {
     override lazy val canonicalCode: Int = 5
     override lazy val isOk: Boolean = false
   }
-  case object AlreadyExists extends SpanStatus with Camelcase {
+  case object AlreadyExists extends SpanStatus("AlreadyExists") {
     override lazy val canonicalCode: Int = 6
     override lazy val isOk: Boolean = false
   }
-  case object PermissionDenied extends SpanStatus with Camelcase {
+  case object PermissionDenied extends SpanStatus("PermissionDenied") {
     override lazy val canonicalCode: Int = 7
     override lazy val isOk: Boolean = false
   }
-  case object ResourceExhausted extends SpanStatus with Camelcase {
+  case object ResourceExhausted extends SpanStatus("ResourceExhausted") {
     override lazy val canonicalCode: Int = 8
     override lazy val isOk: Boolean = false
   }
-  case object FailedPrecondition extends SpanStatus with Camelcase {
+  case object FailedPrecondition extends SpanStatus("FailedPrecondition") {
     override lazy val canonicalCode: Int = 9
     override lazy val isOk: Boolean = false
   }
-  case object Aborted extends SpanStatus with Camelcase {
+  case object Aborted extends SpanStatus("Aborted") {
     override lazy val canonicalCode: Int = 10
     override lazy val isOk: Boolean = false
   }
-  case object OutOfRange extends SpanStatus with Camelcase {
+  case object OutOfRange extends SpanStatus("OutOfRange") {
     override lazy val canonicalCode: Int = 11
     override lazy val isOk: Boolean = false
   }
-  case object Unimplemented extends SpanStatus with Camelcase {
+  case object Unimplemented extends SpanStatus("Unimplemented") {
     override lazy val canonicalCode: Int = 12
     override lazy val isOk: Boolean = false
   }
-  case class Internal(message: String) extends SpanStatus with Camelcase {
+  case class Internal(message: String) extends SpanStatus("Internal") {
     override lazy val canonicalCode: Int = 13
     override lazy val isOk: Boolean = false
   }
-  case object Unavailable extends SpanStatus with Camelcase {
+  case object Unavailable extends SpanStatus("Unavailable") {
     override lazy val canonicalCode: Int = 14
     override lazy val isOk: Boolean = false
   }
-  case object DataLoss extends SpanStatus with Camelcase {
+  case object DataLoss extends SpanStatus("DataLoss") {
     override lazy val canonicalCode: Int = 15
     override lazy val isOk: Boolean = false
   }
-  case object Unauthenticated extends SpanStatus with Camelcase {
+  case object Unauthenticated extends SpanStatus("Unauthenticated") {
     override lazy val canonicalCode: Int = 16
     override lazy val isOk: Boolean = false
   }
+
+  implicit val eq: Eq[SpanStatus] = Eq.fromUniversalEquals
+  implicit val show: Show[SpanStatus] = Show.show(_.entryName)
 }

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanStatus.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanStatus.scala
@@ -76,6 +76,6 @@ object SpanStatus {
     override lazy val isOk: Boolean = false
   }
 
-  implicit val eq: Eq[SpanStatus] = Eq.fromUniversalEquals
+  implicit val eq: Eq[SpanStatus] = Eq.by(_.canonicalCode)
   implicit val show: Show[SpanStatus] = Show.show(_.entryName)
 }

--- a/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/NewRelicSpanCompleter.scala
+++ b/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/NewRelicSpanCompleter.scala
@@ -33,9 +33,9 @@ object NewRelicSpanCompleter {
     endpoint: Endpoint,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(NewRelicSpanExporter[F, Chunk](client, apiKey, endpoint))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      Resource
+        .eval(NewRelicSpanExporter[F, Chunk](client, apiKey, endpoint))
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/opentelemetry-jaeger-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleter.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleter.scala
@@ -15,9 +15,8 @@ object OpenTelemetryJaegerSpanCompleter {
     port: Int = 14250,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- OpenTelemetryJaegerSpanExporter[F, Chunk](host, port)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      OpenTelemetryJaegerSpanExporter[F, Chunk](host, port)
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
@@ -15,9 +15,7 @@ object OpenTelemetryOtlpGrpcSpanCompleter {
     port: Int = 55680,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port).flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/opentelemetry-otlp-http-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleter.scala
@@ -33,9 +33,9 @@ object OpenTelemetryOtlpHttpSpanCompleter {
     port: Int = 55681,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(OpenTelemetryOtlpHttpSpanExporter[F, Chunk](client, host, port))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      Resource
+        .eval(OpenTelemetryOtlpHttpSpanExporter[F, Chunk](client, host, port))
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/rate-sampling/src/main/scala/io/janstenpickle/trace4cats/rate/DynamicTokenBucket.scala
+++ b/modules/rate-sampling/src/main/scala/io/janstenpickle/trace4cats/rate/DynamicTokenBucket.scala
@@ -19,7 +19,7 @@ object DynamicTokenBucket {
     for {
       currentConfig <- Resource.eval(Ref.of[F, (Int, FiniteDuration)]((bucketSize, tokenRate)))
       tokens <- Resource.eval(Ref.of(bucketSize))
-      (hotswap, _) <- Hotswap(TokenBucket.bucketProcess(tokens, bucketSize, tokenRate).background.void)
+      hotswap <- Hotswap(TokenBucket.bucketProcess(tokens, bucketSize, tokenRate).background.void).map(_._1)
     } yield new DynamicTokenBucket[F] {
       private final val underlying = TokenBucket.impl[F](tokens)
 

--- a/modules/stackdriver-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverGrpcSpanCompleter.scala
+++ b/modules/stackdriver-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverGrpcSpanCompleter.scala
@@ -19,9 +19,8 @@ object StackdriverGrpcSpanCompleter {
     requestTimeout: FiniteDuration = 5.seconds,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- StackdriverGrpcSpanExporter[F, Chunk](projectId, credentials, requestTimeout)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      StackdriverGrpcSpanExporter[F, Chunk](projectId, credentials, requestTimeout)
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverHttpSpanCompleter.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverHttpSpanCompleter.scala
@@ -5,7 +5,7 @@ import fs2.Chunk
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, QueuedSpanCompleter}
-import io.janstenpickle.trace4cats.kernel.SpanCompleter
+import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanExporter}
 import io.janstenpickle.trace4cats.model.TraceProcess
 import io.janstenpickle.trace4cats.stackdriver.oauth.TokenProvider
 import io.janstenpickle.trace4cats.stackdriver.project.ProjectIdProvider
@@ -20,24 +20,18 @@ object StackdriverHttpSpanCompleter {
     serviceAccountPath: String,
     config: CompleterConfig = CompleterConfig(),
     ec: Option[ExecutionContext] = None
-  ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- StackdriverHttpSpanExporter.serviceAccountBlazeClient[F, Chunk](projectId, serviceAccountPath, ec)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+  ): Resource[F, SpanCompleter[F]] = makeSpanCompleter[F](process, config)(implicit logger =>
+    StackdriverHttpSpanExporter.serviceAccountBlazeClient[F, Chunk](projectId, serviceAccountPath, ec)
+  )
 
   def blazeClient[F[_]: Async](
     process: TraceProcess,
     serviceAccountName: String = "default",
     config: CompleterConfig = CompleterConfig(),
     ec: Option[ExecutionContext] = None
-  ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- StackdriverHttpSpanExporter.blazeClient[F, Chunk](serviceAccountName, ec)
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+  ): Resource[F, SpanCompleter[F]] = makeSpanCompleter[F](process, config)(implicit logger =>
+    StackdriverHttpSpanExporter.blazeClient[F, Chunk](serviceAccountName, ec)
+  )
 
   def serviceAccount[F[_]: Async](
     process: TraceProcess,
@@ -45,24 +39,18 @@ object StackdriverHttpSpanCompleter {
     projectId: String,
     serviceAccountPath: String,
     config: CompleterConfig = CompleterConfig(),
-  ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(StackdriverHttpSpanExporter[F, Chunk](projectId, serviceAccountPath, client))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+  ): Resource[F, SpanCompleter[F]] = makeSpanCompleter[F](process, config)(implicit logger =>
+    Resource.eval(StackdriverHttpSpanExporter[F, Chunk](projectId, serviceAccountPath, client))
+  )
 
   def apply[F[_]: Async](
     process: TraceProcess,
     client: Client[F],
     serviceAccountName: String = "default",
     config: CompleterConfig = CompleterConfig(),
-  ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(StackdriverHttpSpanExporter[F, Chunk](client, serviceAccountName))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+  ): Resource[F, SpanCompleter[F]] = makeSpanCompleter[F](process, config)(implicit logger =>
+    Resource.eval(StackdriverHttpSpanExporter[F, Chunk](client, serviceAccountName))
+  )
 
   def fromProviders[F[_]: Async](
     process: TraceProcess,
@@ -70,10 +58,17 @@ object StackdriverHttpSpanCompleter {
     tokenProvider: TokenProvider[F],
     client: Client[F],
     config: CompleterConfig = CompleterConfig(),
-  ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(StackdriverHttpSpanExporter[F, Chunk](projectIdProvider, tokenProvider, client))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+  ): Resource[F, SpanCompleter[F]] = makeSpanCompleter[F](process, config)(_ =>
+    Resource.eval(StackdriverHttpSpanExporter[F, Chunk](projectIdProvider, tokenProvider, client))
+  )
+
+  private def makeSpanCompleter[F[_]: Async](process: TraceProcess, config: CompleterConfig)(
+    exporter: Logger[F] => Resource[F, SpanExporter[F, Chunk]]
+  ): Resource[F, SpanCompleter[F]] = {
+    Resource
+      .eval(Slf4jLogger.create[F])
+      .flatMap { implicit logger: Logger[F] =>
+        exporter(logger).flatMap(QueuedSpanCompleter[F](process, _, config))
+      }
+  }
 }

--- a/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleter.scala
+++ b/modules/zipkin-http-exporter/src/main/scala/io/janstenpickle/trace4cats/zipkin/ZipkinHttpSpanCompleter.scala
@@ -34,11 +34,11 @@ object ZipkinHttpSpanCompleter {
     port: Int = 9411,
     config: CompleterConfig = CompleterConfig()
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(ZipkinHttpSpanExporter[F, Chunk](client, host, port))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      Resource
+        .eval(ZipkinHttpSpanExporter[F, Chunk](client, host, port))
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 
   def apply[F[_]: Async](
     client: Client[F],
@@ -46,9 +46,9 @@ object ZipkinHttpSpanCompleter {
     uri: String,
     config: CompleterConfig
   ): Resource[F, SpanCompleter[F]] =
-    for {
-      implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.create[F])
-      exporter <- Resource.eval(ZipkinHttpSpanExporter[F, Chunk](client, uri))
-      completer <- QueuedSpanCompleter[F](process, exporter, config)
-    } yield completer
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      Resource
+        .eval(ZipkinHttpSpanExporter[F, Chunk](client, uri))
+        .flatMap(QueuedSpanCompleter[F](process, _, config))
+    }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
     val circeYaml = "0.13.1"
     val decline = "2.0.0"
     val embeddedRedis = "0.7.3"
-    val enumeratum = "1.6.1"
     val fs2 = "3.0.4"
     val fs2Kafka = "2.1.0"
     val googleCredentials = "0.26.0"
@@ -60,9 +59,6 @@ object Dependencies {
   lazy val circeYaml = "io.circe"                              %% "circe-yaml"                      % Versions.circeYaml
   lazy val embeddedKafka = "io.github.embeddedkafka"           %% "embedded-kafka"                  % Versions.kafka
   lazy val embeddedRedis = "it.ozimov"                          % "embedded-redis"                  % Versions.embeddedRedis
-  lazy val enumeratum = "com.beachape"                         %% "enumeratum"                      % Versions.enumeratum
-  lazy val enumeratumCats = "com.beachape"                     %% "enumeratum-cats"                 % Versions.enumeratum
-  lazy val enumeratumCirce = "com.beachape"                    %% "enumeratum-circe"                % Versions.enumeratum
   lazy val declineEffect = "com.monovore"                      %% "decline-effect"                  % Versions.decline
   lazy val googleCredentials = "com.google.auth"                % "google-auth-library-credentials" % Versions.googleCredentials
   lazy val googleCloudTrace = "com.google.cloud"                % "google-cloud-trace"              % Versions.googleCloudTrace
@@ -104,7 +100,6 @@ object Dependencies {
   lazy val svm = "com.oracle.substratevm"                       % "svm"                             % Versions.svm % "provided"
   lazy val vulcan = "com.github.fd4s"                          %% "vulcan"                          % Versions.vulcan
   lazy val vulcanGeneric = "com.github.fd4s"                   %% "vulcan-generic"                  % Versions.vulcan
-  lazy val vulcanEnumeratum = "com.github.fd4s"                %% "vulcan-enumeratum"               % Versions.vulcan
   lazy val zioInterop = "dev.zio"                              %% "zio-interop-cats"                % Versions.zioInterop
 
   lazy val catsLaws = "org.typelevel"             %% "cats-laws"              % Versions.cats


### PR DESCRIPTION
This PR removes enumeratum as a dependency (wasn't used too much anyway) and rewrites for-comprehensions in a way that the code compiles also without the `better-monadic-for` compiler plugin, as it will be the case on Scala 3 (there's `source:future`, but the rewrites are IMHO mostly not uglier to read than the original versions, so easier that way).

Contributes to resolving #229 in baby steps.